### PR TITLE
Update README and Website Headings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,8 @@
-= Address Book (Level 3)
+= ResuMe
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level3[image:https://travis-ci.org/se-edu/addressbook-level3.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level3[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://travis-ci.com/AY1920S2-CS2103T-F10-1/main[image:https://travis-ci.com/AY1920S2-CS2103T-F10-1/main.svg?branch=master[Build Status]]
 https://coveralls.io/github/AY1920S2-CS2103T-F10-1/main?branch=master[image:https://coveralls.io/repos/github/AY1920S2-CS2103T-F10-1/main/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level3?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level3&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 
 
 ifdef::env-github[]
@@ -15,7 +13,7 @@ ifndef::env-github[]
 image::images/Ui.png[width="600"]
 endif::[]
 
-* This is a desktop Address Book application. It has a GUI but most of the user interactions happen using a CLI (Command Line Interface).
+* This is a desktop Resume management application. It has a GUI but most of the user interactions happen using a CLI (Command Line Interface).
 * It is a Java sample application intended for students learning Software Engineering while using Java as the main programming language.
 * It is *written in OOP fashion*. It provides a *reasonably well-written* code example that is *significantly bigger* (around 6 KLoC)than what students usually write in beginner-level SE modules.
 
@@ -23,7 +21,6 @@ endif::[]
 
 * <<UserGuide#, User Guide>>
 * <<DeveloperGuide#, Developer Guide>>
-* <<LearningOutcomes#, Learning Outcomes>>
 * <<AboutUs#, About Us>>
 * <<ContactUs#, Contact Us>>
 
@@ -32,6 +29,7 @@ endif::[]
 * Some parts of this sample application were inspired by the excellent http://code.makery.ch/library/javafx-8-tutorial/[Java FX tutorial] by
 _Marco Jakob_.
 * Libraries used: https://openjfx.io/[JavaFX], https://github.com/FasterXML/jackson[Jackson], https://github.com/junit-team/junit5[JUnit5]
+* The starting point of this code is AddressBook-Level3 project created by https://se-education.org[SE-EDU initiative]
 
 == Licence : link:LICENSE[MIT]
 

--- a/docs/DevOps.adoc
+++ b/docs/DevOps.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - Dev Ops
+= ResuMe - Dev Ops
 :site-section: DeveloperGuide
 :toc:
 :toc-title:

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - Developer Guide
+= ResuMe - Developer Guide
 :site-section: DeveloperGuide
 :toc:
 :toc-title:

--- a/docs/Documentation.adoc
+++ b/docs/Documentation.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - Documentation
+= ResuMe - Documentation
 :site-section: DeveloperGuide
 :toc:
 :toc-title:

--- a/docs/SettingUp.adoc
+++ b/docs/SettingUp.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - Setting Up
+= ResuMe - Setting Up
 :site-section: DeveloperGuide
 :toc:
 :toc-title:

--- a/docs/Testing.adoc
+++ b/docs/Testing.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - Testing
+= ResuMe - Testing
 :site-section: DeveloperGuide
 :toc:
 :toc-title:

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3 - User Guide
+= ResuMe - User Guide
 :site-section: UserGuide
 :toc:
 :toc-title:


### PR DESCRIPTION
Make README more reflective of the current project and remove references to AB3 in Website Headings (replacing with ResuMe)