### PR TITLE
Parse Internship properly for AddCommand

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -13,6 +17,7 @@ import seedu.address.logic.commands.AddInternshipCommand;
 import seedu.address.logic.commands.AddResumeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Internship;
+import seedu.address.model.item.Item;
 import seedu.address.model.item.Resume;
 import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Time;
@@ -30,16 +35,18 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ITEM);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ITEM, PREFIX_FROM, PREFIX_TO,
+                        PREFIX_ROLE, PREFIX_DESCRIPTION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_ITEM) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException("You are required to specify Item type!");
+            throw new ParseException(Item.MESSAGE_CONSTRAINTS);
         }
 
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
         Name name;
         Set<Tag> tagList;
+        String description;
 
         switch(itemType) {
         case ("res"):
@@ -55,18 +62,19 @@ public class AddCommandParser implements Parser<AddCommand> {
 
             return new AddResumeCommand(resume);
         case ("int"):
-            // This may change, so I will leave it here first despite the duplication
-            if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
+            if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FROM, PREFIX_ROLE, PREFIX_ROLE, PREFIX_DESCRIPTION)
                     || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
             }
 
-            // TODO: Parse the correct things
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            Time from = ParserUtil.parseTime(argMultimap.getValue(PREFIX_FROM).get());
+            Time to = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TO).get());
+            String role = argMultimap.getValue(PREFIX_ROLE).get().trim();
+            description = argMultimap.getValue(PREFIX_DESCRIPTION).get().trim();
             tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-            Internship internship = new Internship(name, "role", new Time("02-2019"), new Time("05-2020"),
-                    "decription", tagList);
+            Internship internship = new Internship(name, role, from, to, description, tagList);
             return new AddInternshipCommand(internship);
         default:
             // Should not have reached here

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,7 +15,7 @@ public class CliSyntax {
     /* Items */
     public static final Prefix PREFIX_ITEM = new Prefix("i/");
     public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TAG = new Prefix("#/");
 
     /* Internship */
     public static final Prefix PREFIX_FROM = new Prefix("f/");

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -6,6 +6,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListInternshipCommand;
 import seedu.address.logic.commands.ListResumeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.Item;
 
 /**
  * Parses input arguments and creates a new ListCommand object
@@ -21,7 +22,7 @@ public class ListCommandParser implements Parser<ListCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ITEM);
 
         if (!argMultimap.getValue(PREFIX_ITEM).isPresent() || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException("You are required to specify Item type!");
+            throw new ParseException(Item.MESSAGE_CONSTRAINTS);
         }
 
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import seedu.address.model.item.field.Address;
 import seedu.address.model.item.field.Email;
 import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Phone;
+import seedu.address.model.item.field.Time;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -124,7 +125,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String email} into an {@code Email}.
+     * Parses an {@code String itemType} into a {@code String}.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code email} is invalid.
@@ -138,4 +139,18 @@ public class ParserUtil {
         return trimmedItemType;
     }
 
+    /**
+     * Parses a {@code String time} in MM-YYYY format into a {@code Time}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code email} is invalid.
+     */
+    public static Time parseTime(String time) throws ParseException {
+        requireNonNull(time);
+        String trimmedTime = time.trim();
+        if (!Time.isValidTime(trimmedTime)) {
+            throw new ParseException(Time.MESSAGE_CONSTRAINTS);
+        }
+        return new Time(trimmedTime);
+    }
 }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -17,6 +17,8 @@ import seedu.address.model.tag.Tag;
  */
 public abstract class Item {
 
+    public static final String MESSAGE_CONSTRAINTS = "You are required to specify an item type! For example: i/ res";
+
     // Class-level fields
     protected static int itemCount = 0;
 


### PR DESCRIPTION
In this PR, the parser will properly read the input of the user to create a corresponding `Internship` object rather than creating an `Internship` object with dummy values
