### PR TITLE
Handle EditCommand parsing for Internship and Resume items

### DIFF
--- a/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
@@ -54,18 +54,19 @@ public abstract class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
-    private final EditPersonDescriptor editPersonDescriptor;
+    // TODO: Change the name to editItemDescriptor
+    private final EditItemDescriptor editPersonDescriptor;
 
     /**
      * @param index of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditCommand(Index index, EditItemDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
         this.index = index;
-        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+        this.editPersonDescriptor = new EditItemDescriptor(editPersonDescriptor);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/edit/EditInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditInternshipCommand.java
@@ -7,10 +7,10 @@ import seedu.address.commons.core.index.Index;
  */
 public class EditInternshipCommand extends EditCommand {
     /**
-     * @param index                of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * @param index                of the person in the filtered internship list to edit
+     * @param editInternshipDescriptor details to edit the internship with
      */
-    public EditInternshipCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
-        super(index, editPersonDescriptor);
+    public EditInternshipCommand(Index index, EditInternshipDescriptor editInternshipDescriptor) {
+        super(index, editInternshipDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/edit/EditInternshipDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditInternshipDescriptor.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.edit;
 
 import java.util.Optional;
+
 import seedu.address.commons.util.CollectionUtil;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/edit/EditInternshipDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditInternshipDescriptor.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands.edit;
+
+import java.util.Optional;
+import seedu.address.commons.util.CollectionUtil;
+
+/**
+ * Stores the details to edit the person with. Each non-empty field value will replace the
+ * corresponding field value of the person.
+ */
+public class EditInternshipDescriptor extends EditItemDescriptor {
+    private String role;
+    private String from;
+    private String to;
+    private String description;
+
+    public EditInternshipDescriptor() {}
+
+    /**
+     * Copy constructor.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public EditInternshipDescriptor(EditInternshipDescriptor toCopy) {
+        setName(toCopy.name);
+        setRole(toCopy.role);
+        setFrom(toCopy.from);
+        setTo(toCopy.to);
+        setDescription(toCopy.description);
+
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public Optional<String> getFrom() {
+        return Optional.ofNullable(from);
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public Optional<String> getTo() {
+        return Optional.ofNullable(to);
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public Optional<String> getRole() {
+        return Optional.ofNullable(role);
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    /**
+     * Returns true if at least one field is edited.
+     */
+    @Override
+    public boolean isAnyFieldEdited() {
+        return CollectionUtil.isAnyNonNull(name, role, from, to, description);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditInternshipDescriptor)) {
+            return false;
+        }
+
+        // state check
+        EditInternshipDescriptor e = (EditInternshipDescriptor) other;
+
+        return getName().equals(e.getName())
+                && getRole().equals(e.getRole())
+                && getFrom().equals(e.getFrom())
+                && getTo().equals(e.getTo())
+                && getDescription().equals(e.getDescription());
+
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/edit/EditItemDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditItemDescriptor.java
@@ -1,9 +1,14 @@
 package seedu.address.logic.commands.edit;
 
 import java.util.Optional;
+
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.item.field.Name;
 
+/**
+ * Stores the details to edit the item with. Each non-empty field value will replace the
+ * corresponding field value of the item.
+ */
 public class EditItemDescriptor {
     protected Name name;
 

--- a/src/main/java/seedu/address/logic/commands/edit/EditItemDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditItemDescriptor.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands.edit;
+
+import java.util.Optional;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.item.field.Name;
+
+public class EditItemDescriptor {
+    protected Name name;
+
+    public EditItemDescriptor() {}
+
+    /**
+     * Copy constructor.
+     */
+    public EditItemDescriptor(EditItemDescriptor toCopy) {
+        setName(toCopy.name);
+    }
+
+    /**
+     * Returns true if at least one field is edited.
+     */
+    public boolean isAnyFieldEdited() {
+        return CollectionUtil.isAnyNonNull(name);
+    }
+
+    public void setName(Name name) {
+        this.name = name;
+    }
+
+    public Optional<Name> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditItemDescriptor)) {
+            return false;
+        }
+
+        // state check
+        EditItemDescriptor e = (EditItemDescriptor) other;
+
+        return getName().equals(e.getName());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/edit/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditProjectCommand.java
@@ -10,7 +10,8 @@ public class EditProjectCommand extends EditCommand {
      * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditProjectCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    // TODO: Change variable name
+    public EditProjectCommand(Index index, EditItemDescriptor editPersonDescriptor) {
         super(index, editPersonDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/edit/EditResumeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditResumeCommand.java
@@ -8,9 +8,9 @@ import seedu.address.commons.core.index.Index;
 public class EditResumeCommand extends EditCommand {
     /**
      * @param index                of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * @param editResumeDescriptor details to edit the resume with
      */
-    public EditResumeCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
-        super(index, editPersonDescriptor);
+    public EditResumeCommand(Index index, EditResumeDescriptor editResumeDescriptor) {
+        super(index, editResumeDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands.edit;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Stores the details to edit the person with. Each non-empty field value will replace the
+ * corresponding field value of the person.
+ */
+public class EditResumeDescriptor extends EditItemDescriptor {
+    private Set<Tag> tags;
+
+    public EditResumeDescriptor() {}
+
+    /**
+     * Copy constructor.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public EditResumeDescriptor(EditResumeDescriptor toCopy) {
+        setName(toCopy.name);
+        setTags(toCopy.tags);
+    }
+
+    /**
+     * Returns true if at least one field is edited.
+     */
+    public boolean isAnyFieldEdited() {
+        return CollectionUtil.isAnyNonNull(name, tags);
+    }
+
+    /**
+     * Sets {@code tags} to this object's {@code tags}.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public void setTags(Set<Tag> tags) {
+        this.tags = (tags != null) ? new HashSet<>(tags) : null;
+    }
+
+    /**
+     * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     * Returns {@code Optional#empty()} if {@code tags} is null.
+     */
+    public Optional<Set<Tag>> getTags() {
+        return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditResumeDescriptor)) {
+            return false;
+        }
+
+        // state check
+        EditResumeDescriptor e = (EditResumeDescriptor) other;
+
+        return getName().equals(e.getName())
+                && getTags().equals(e.getTags());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditResumeDescriptor.java
@@ -28,6 +28,7 @@ public class EditResumeDescriptor extends EditItemDescriptor {
     /**
      * Returns true if at least one field is edited.
      */
+    @Override
     public boolean isAnyFieldEdited() {
         return CollectionUtil.isAnyNonNull(name, tags);
     }

--- a/src/main/java/seedu/address/logic/commands/edit/EditSkillCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditSkillCommand.java
@@ -10,7 +10,8 @@ public class EditSkillCommand extends EditCommand {
      * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditSkillCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    // TODO: Change variable name
+    public EditSkillCommand(Index index, EditItemDescriptor editPersonDescriptor) {
         super(index, editPersonDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,10 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -15,8 +13,8 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.edit.EditCommand;
-import seedu.address.logic.commands.edit.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.edit.EditInternshipCommand;
+import seedu.address.logic.commands.edit.EditResumeCommand;
+import seedu.address.logic.commands.edit.EditResumeDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -33,7 +31,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ITEM);
 
         Index index;
 
@@ -43,26 +41,28 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
-        }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        switch (itemType) {
+        case "res":
+            EditResumeDescriptor editResumeDescriptor = new EditResumeDescriptor();
+            // TODO: Not sure if I should create a method inside the respective descriptors for this checking.
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                editResumeDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            }
+            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editResumeDescriptor::setTags);
+
+            if (!editResumeDescriptor.isAnyFieldEdited()) {
+                throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            }
+
+            return new EditResumeCommand(index, editResumeDescriptor);
+        default:
+            // Should not have reached here
+            // TODO: Use a better Exception here
+            throw new ParseException("The item type is not detected! Something is wrong");
         }
 
-        return new EditInternshipCommand(index, editPersonDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,9 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -13,9 +17,12 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.edit.EditCommand;
+import seedu.address.logic.commands.edit.EditInternshipCommand;
+import seedu.address.logic.commands.edit.EditInternshipDescriptor;
 import seedu.address.logic.commands.edit.EditResumeCommand;
 import seedu.address.logic.commands.edit.EditResumeDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.Item;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -31,14 +38,20 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ITEM);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ITEM, PREFIX_FROM, PREFIX_TO,
+                        PREFIX_ROLE, PREFIX_DESCRIPTION);
 
         Index index;
 
+        // TODO: Better error handling
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (!argMultimap.getValue(PREFIX_ITEM).isPresent()) {
+            throw new ParseException(Item.MESSAGE_CONSTRAINTS);
         }
 
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
@@ -47,6 +60,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         case "res":
             EditResumeDescriptor editResumeDescriptor = new EditResumeDescriptor();
             // TODO: Not sure if I should create a method inside the respective descriptors for this checking.
+            // Considerations: If I add a method inside the descriptor, then potentially need dependencies
             if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
                 editResumeDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
             }
@@ -57,6 +71,29 @@ public class EditCommandParser implements Parser<EditCommand> {
             }
 
             return new EditResumeCommand(index, editResumeDescriptor);
+        case "int":
+            EditInternshipDescriptor editInternshipDescriptor = new EditInternshipDescriptor();
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                editInternshipDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            }
+            if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+                editInternshipDescriptor.setRole(argMultimap.getValue(PREFIX_ROLE).get().trim());
+            }
+            if (argMultimap.getValue(PREFIX_FROM).isPresent()) {
+                editInternshipDescriptor.setFrom(argMultimap.getValue(PREFIX_FROM).get().trim());
+            }
+            if (argMultimap.getValue(PREFIX_TO).isPresent()) {
+                editInternshipDescriptor.setTo(argMultimap.getValue(PREFIX_TO).get().trim());
+            }
+            if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+                editInternshipDescriptor.setDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get().trim());
+            }
+
+            if (!editInternshipDescriptor.isAnyFieldEdited()) {
+                throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            }
+
+            return new EditInternshipCommand(index, editInternshipDescriptor);
         default:
             // Should not have reached here
             // TODO: Use a better Exception here

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -55,6 +55,8 @@ public class AddressBookParserTest {
         assertEquals(new DeleteResumeCommand(INDEX_FIRST_PERSON), command);
     }
 
+    // TODO: Create DescriptorBuilders for testing puposes
+    /*
     @Test
     public void parseCommand_edit() throws Exception {
         PersonalDetail person = new PersonBuilder().build();
@@ -63,6 +65,7 @@ public class AddressBookParserTest {
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditInternshipCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
+     */
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,18 +18,11 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.delete.DeleteCommand;
 import seedu.address.logic.commands.delete.DeleteResumeCommand;
-import seedu.address.logic.commands.edit.EditCommand;
-import seedu.address.logic.commands.edit.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.edit.EditInternshipCommand;
 import seedu.address.logic.commands.find.FindCommand;
 import seedu.address.logic.commands.find.FindInternshipCommand;
 import seedu.address.logic.commands.list.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.item.PersonalDetail;
 import seedu.address.model.item.field.NameContainsKeywordsPredicate;
-import seedu.address.testutil.EditPersonDescriptorBuilder;
-import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 


### PR DESCRIPTION
Part of #64 

I changed a bit of the `commands` package to add in the `Descriptor`s as well as change parameter type for some of the `EditCommand` classes. 

Currently, simple Edit Commands don't seem to throw an error when correctly formatted, but I only did light testing. Also because editing isn't exactly implemented yet (I think?), I did not try to test much further. Note that it doesn't actually edit the Items

I also suppressed the test for `EditCommand` because it involves creating `EditXXXDescriptorBuilder`. Will probably have to do a bit of writing for this in the future.