### PR TITLE
Add ViewCommand and handle its parsing for Internship and Resume items

### DIFF
--- a/src/main/java/seedu/address/logic/commands/stubs/ViewInternshipCommandStub.java
+++ b/src/main/java/seedu/address/logic/commands/stubs/ViewInternshipCommandStub.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands.stubs;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.view.ViewCommand;
+import seedu.address.model.Model;
+
+public class ViewInternshipCommandStub extends ViewCommand {
+    private Index targetIndex;
+
+    public ViewInternshipCommandStub(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/stubs/ViewInternshipCommandStub.java
+++ b/src/main/java/seedu/address/logic/commands/stubs/ViewInternshipCommandStub.java
@@ -5,6 +5,9 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.model.Model;
 
+/**
+ * Stub for ViewInternshipCommand.
+ */
 public class ViewInternshipCommandStub extends ViewCommand {
     private Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/stubs/ViewResumeCommandStub.java
+++ b/src/main/java/seedu/address/logic/commands/stubs/ViewResumeCommandStub.java
@@ -5,6 +5,9 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.model.Model;
 
+/**
+ * Stub for ViewResumeCommand.
+ */
 public class ViewResumeCommandStub extends ViewCommand {
     private Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/stubs/ViewResumeCommandStub.java
+++ b/src/main/java/seedu/address/logic/commands/stubs/ViewResumeCommandStub.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands.stubs;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.view.ViewCommand;
+import seedu.address.model.Model;
+
+public class ViewResumeCommandStub extends ViewCommand {
+    private Index targetIndex;
+
+    public ViewResumeCommandStub(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands.view;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+
+public abstract class ViewCommand extends Command {
+
+    public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_VIEW_SUCCESS = "Viewing this item!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "index i/ itemType\n"
+            + "Example: view 1 i/int";
+
+    protected final Index targetIndex;
+
+    public ViewCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
@@ -3,6 +3,9 @@ package seedu.address.logic.commands.view;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 
+/**
+ * Views the details of an item in the ResuMe application.
+ */
 public abstract class ViewCommand extends Command {
 
     public static final String COMMAND_WORD = "view";

--- a/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/view/ViewCommand.java
@@ -13,6 +13,12 @@ public abstract class ViewCommand extends Command {
 
     protected final Index targetIndex;
 
+    // This default constructor is needed for the stub
+    public ViewCommand() {
+        this.targetIndex = null;
+    }
+
+
     public ViewCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }

--- a/src/main/java/seedu/address/logic/commands/view/ViewInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/view/ViewInternshipCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands.view;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+
+/**
+ * Stub for ViewInternshipCommand.
+ */
+public class ViewInternshipCommand extends ViewCommand {
+    private Index targetIndex;
+
+    public ViewInternshipCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/view/ViewResumeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/view/ViewResumeCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands.view;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+
+/**
+ * Stub for ViewResumeCommand.
+ */
+public class ViewResumeCommand extends ViewCommand {
+    private Index targetIndex;
+
+    public ViewResumeCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
@@ -8,18 +8,15 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.add.AddCommand;
 import seedu.address.logic.commands.delete.DeleteCommand;
 import seedu.address.logic.commands.edit.EditCommand;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.find.FindCommand;
 import seedu.address.logic.commands.list.ListCommand;
 import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.Model;
 
 /**
  * Parses user input.

--- a/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
@@ -8,14 +8,18 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.add.AddCommand;
 import seedu.address.logic.commands.delete.DeleteCommand;
 import seedu.address.logic.commands.edit.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.find.FindCommand;
 import seedu.address.logic.commands.list.ListCommand;
+import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 
 /**
  * Parses user input.
@@ -67,6 +71,9 @@ public class ResumeBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.stubs.ViewInternshipCommandStub;
+import seedu.address.logic.commands.stubs.ViewResumeCommandStub;
+import seedu.address.logic.commands.view.ViewCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.item.Item;
+
+public class ViewCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ViewCommand
+     * and returns a ViewCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ViewCommand parse(String args) throws ParseException {
+        // The code is actually identical to DeleteCommand
+        try {
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ITEM);
+
+            if (!argMultimap.getValue(PREFIX_ITEM).isPresent()) {
+                throw new ParseException(Item.MESSAGE_CONSTRAINTS);
+            }
+
+            String preamble = argMultimap.getPreamble();
+            Index index = ParserUtil.parseIndex(preamble);
+
+            String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
+
+            switch(itemType) {
+            case("res"):
+                return new ViewResumeCommandStub(index);
+            case("int"):
+                return new ViewInternshipCommandStub(index);
+            default:
+                // Should not have reached here
+                // TODO: Use a better Exception here
+                throw new ParseException("The item type is not detected! Something is wrong");
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -4,9 +4,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.stubs.ViewInternshipCommandStub;
-import seedu.address.logic.commands.stubs.ViewResumeCommandStub;
 import seedu.address.logic.commands.view.ViewCommand;
+import seedu.address.logic.commands.view.ViewInternshipCommand;
+import seedu.address.logic.commands.view.ViewResumeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
 
@@ -35,9 +35,9 @@ public class ViewCommandParser {
 
             switch(itemType) {
             case("res"):
-                return new ViewResumeCommandStub(index);
+                return new ViewResumeCommand(index);
             case("int"):
-                return new ViewInternshipCommandStub(index);
+                return new ViewInternshipCommand(index);
             default:
                 // Should not have reached here
                 // TODO: Use a better Exception here

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -10,6 +10,9 @@ import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
 
+/**
+ * Parses input arguments and creates a new ViewCommand object
+ */
 public class ViewCommandParser {
     /**
      * Parses the given {@code String} of arguments in the context of the ViewCommand

--- a/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
@@ -46,8 +46,8 @@ public class ResumeBookParserTest {
     @Test
     public void parseCommand_view() throws Exception {
         ViewCommand command = (ViewCommand) parser.parseCommand(
-                ViewResumeCommandStub.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " i/ res");
-        assertEquals(new ViewResumeCommandStub(INDEX_FIRST_PERSON), command);
+                ViewResumeCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " i/ res");
+        assertEquals(new ViewResumeCommand(INDEX_FIRST_PERSON), command);
     }
      */
 

--- a/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
@@ -21,6 +21,8 @@ import seedu.address.logic.commands.delete.DeleteResumeCommand;
 import seedu.address.logic.commands.find.FindCommand;
 import seedu.address.logic.commands.find.FindInternshipCommand;
 import seedu.address.logic.commands.list.ListCommand;
+import seedu.address.logic.commands.stubs.ViewResumeCommandStub;
+import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.field.NameContainsKeywordsPredicate;
 
@@ -40,6 +42,16 @@ public class ResumeBookParserTest {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
+
+    // TODO: I thought the test would be identical to DeleteCommand but turns out not really..
+    /*
+    @Test
+    public void parseCommand_view() throws Exception {
+        ViewCommand command = (ViewCommand) parser.parseCommand(
+                ViewResumeCommandStub.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " i/ res");
+        assertEquals(new ViewResumeCommandStub(INDEX_FIRST_PERSON), command);
+    }
+     */
 
     @Test
     public void parseCommand_delete() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeBookParserTest.java
@@ -21,8 +21,6 @@ import seedu.address.logic.commands.delete.DeleteResumeCommand;
 import seedu.address.logic.commands.find.FindCommand;
 import seedu.address.logic.commands.find.FindInternshipCommand;
 import seedu.address.logic.commands.list.ListCommand;
-import seedu.address.logic.commands.stubs.ViewResumeCommandStub;
-import seedu.address.logic.commands.view.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.field.NameContainsKeywordsPredicate;
 


### PR DESCRIPTION
Part of #64 

I think it's very similar to `deleteCommand`, and the code is nearly identical.

However, when I added a similar test for `parseCommand_view()`, it could not pass :/ I commented it out just as a reminder for us to fix it later.