### PR TITLE
Refactor usage of aliases

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -32,6 +32,7 @@ import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Time;
 import seedu.address.model.item.field.Website;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -59,7 +60,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         String description;
 
         switch (itemType) {
-        case ("res"):
+        case (ItemUtil.RESUME_ALIAS):
             if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
                     || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddResumeCommand.MESSAGE_USAGE));
@@ -71,7 +72,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             Resume resume = new Resume(name, tagList);
             return new AddResumeCommand(resume);
 
-        case ("int"):
+        case (ItemUtil.INTERNSHIP_ALIAS):
             if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FROM, PREFIX_TO, PREFIX_ROLE, PREFIX_DESCRIPTION)
                     || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -88,7 +89,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             Internship internship = new Internship(name, role, from, to, description, tagList);
             return new AddInternshipCommand(internship);
 
-        case ("proj"):
+        case (ItemUtil.PROJECT_ALIAS):
             if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TIME, PREFIX_WEBSITE, PREFIX_DESCRIPTION)
                     || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -103,7 +104,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             Project project = new Project(name, time, website, description, tagList);
             return new AddProjectCommand(project);
 
-        case("ski"):
+        case(ItemUtil.SKILL_ALIAS):
             if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_LEVEL) || !argMultimap.getPreamble().isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                         AddSkillCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import seedu.address.model.util.ItemUtil;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
@@ -33,10 +35,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_LEVEL = new Prefix("l/");
 
     /* Prefixes for different item types */
-    public static final Prefix PREFIX_INTERNSHIP = new Prefix("int/");
-    public static final Prefix PREFIX_PROJECT = new Prefix("proj/");
-    public static final Prefix PREFIX_RESUME = new Prefix("res/");
-    public static final Prefix PREFIX_SKILL = new Prefix("ski/");
+    public static final Prefix PREFIX_INTERNSHIP = new Prefix(ItemUtil.INTERNSHIP_ALIAS + "/");
+    public static final Prefix PREFIX_PROJECT = new Prefix(ItemUtil.PROJECT_ALIAS + "/");
+    public static final Prefix PREFIX_RESUME = new Prefix(ItemUtil.RESUME_ALIAS + "/");
+    public static final Prefix PREFIX_SKILL = new Prefix(ItemUtil.SKILL_ALIAS + "/");
 
     /* User */
     public static final Prefix PREFIX_GITHUB = new Prefix("g/");

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.delete.DeleteResumeCommand;
 import seedu.address.logic.commands.delete.DeleteSkillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -36,13 +37,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
             switch (itemType) {
-            case "res":
+            case ItemUtil.RESUME_ALIAS:
                 return new DeleteResumeCommand(index);
-            case "int":
+            case ItemUtil.INTERNSHIP_ALIAS:
                 return new DeleteInternshipCommand(index);
-            case "proj":
+            case ItemUtil.PROJECT_ALIAS:
                 return new DeleteProjectCommand(index);
-            case "ski":
+            case ItemUtil.SKILL_ALIAS:
                 return new DeleteSkillCommand(index);
 
             default:

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.edit.EditSkillDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -64,7 +65,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
         switch (itemType) {
-        case "res":
+        case ItemUtil.RESUME_ALIAS:
             EditResumeDescriptor editResumeDescriptor = new EditResumeDescriptor();
             // TODO: Not sure if I should create a method inside the respective descriptors for this checking.
             // Considerations: If I add a method inside the descriptor, then potentially need dependencies
@@ -78,7 +79,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             }
 
             return new EditResumeCommand(index, editResumeDescriptor);
-        case "int":
+        case ItemUtil.INTERNSHIP_ALIAS:
             EditInternshipDescriptor editInternshipDescriptor = new EditInternshipDescriptor();
             if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
                 editInternshipDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
@@ -102,7 +103,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             }
 
             return new EditInternshipCommand(index, editInternshipDescriptor);
-        case "proj":
+        case ItemUtil.PROJECT_ALIAS:
             EditProjectDescriptor editProjectDescriptor = new EditProjectDescriptor();
             if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
                 editProjectDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
@@ -123,7 +124,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             }
 
             return new EditProjectCommand(index, editProjectDescriptor);
-        case "ski":
+        case ItemUtil.SKILL_ALIAS:
             EditSkillDescriptor editSkillDescriptor = new EditSkillDescriptor();
             if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
                 editSkillDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.find.FindSkillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
 import seedu.address.model.item.field.NameContainsKeywordsPredicate;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -42,13 +43,13 @@ public class FindCommandParser implements Parser<FindCommand> {
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
         switch (itemType) {
-        case "res":
+        case ItemUtil.RESUME_ALIAS:
             return new FindResumeCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-        case "int":
+        case ItemUtil.INTERNSHIP_ALIAS:
             return new FindInternshipCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-        case "proj":
+        case ItemUtil.PROJECT_ALIAS:
             return new FindProjectCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-        case "ski":
+        case ItemUtil.SKILL_ALIAS:
             return new FindSkillCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
 
         default:

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.list.ListResumeCommand;
 import seedu.address.logic.commands.list.ListSkillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new ListCommand object
@@ -30,13 +31,14 @@ public class ListCommandParser implements Parser<ListCommand> {
         String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
         switch(itemType) {
-        case ("int"):
-            return new ListInternshipCommand();
-        case ("proj"):
-            return new ListProjectCommand();
-        case ("res"):
+
+        case ItemUtil.RESUME_ALIAS:
             return new ListResumeCommand();
-        case ("ski"):
+        case ItemUtil.INTERNSHIP_ALIAS:
+            return new ListInternshipCommand();
+        case ItemUtil.PROJECT_ALIAS:
+            return new ListProjectCommand();
+        case ItemUtil.SKILL_ALIAS:
             return new ListSkillCommand();
         default:
             // Should not have reached here

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.view.ViewResumeCommand;
 import seedu.address.logic.commands.view.ViewSkillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.Item;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Parses input arguments and creates a new ViewCommand object
@@ -36,13 +37,13 @@ public class ViewCommandParser {
             String itemType = ParserUtil.parseItemType(argMultimap.getValue(PREFIX_ITEM).get());
 
             switch(itemType) {
-            case "res":
+            case ItemUtil.RESUME_ALIAS:
                 return new ViewResumeCommand(index);
-            case "int":
+            case ItemUtil.INTERNSHIP_ALIAS:
                 return new ViewInternshipCommand(index);
-            case "proj":
+            case ItemUtil.PROJECT_ALIAS:
                 return new ViewProjectCommand(index);
-            case "ski":
+            case ItemUtil.SKILL_ALIAS:
                 return new ViewSkillCommand(index);
             default:
                 // Should not have reached here

--- a/src/main/java/seedu/address/model/ResumeBook.java
+++ b/src/main/java/seedu/address/model/ResumeBook.java
@@ -16,6 +16,7 @@ import seedu.address.model.item.field.Github;
 import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Phone;
 import seedu.address.model.item.field.Time;
+import seedu.address.model.util.ItemUtil;
 
 /**
  * Wraps all data at the resume-book level
@@ -75,16 +76,16 @@ public class ResumeBook implements ReadOnlyResumeBook {
      */
     public void setItemsToDisplay(String type) {
         switch (type) {
-        case "int":
+        case ItemUtil.INTERNSHIP_ALIAS:
             setInternshipToDisplay();
             break;
-        case "proj":
+        case ItemUtil.PROJECT_ALIAS:
             setProjectToDisplay();
             break;
-        case "ski":
+        case ItemUtil.SKILL_ALIAS:
             setSkillToDisplay();
             break;
-        case "res":
+        case ItemUtil.RESUME_ALIAS:
             setResumeToDisplay();
             break;
         default:
@@ -103,7 +104,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
      * Replaces the contents of the item list to the content of the internship list.
      */
     public void setInternshipToDisplay() {
-        displayType = "int";
+        displayType = ItemUtil.INTERNSHIP_ALIAS;
         setItemsToDisplay(internships);
     }
 
@@ -111,7 +112,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
      * Replaces the contents of the item list to the content of the project list.
      */
     public void setProjectToDisplay() {
-        displayType = "proj";
+        displayType = ItemUtil.PROJECT_ALIAS;
         setItemsToDisplay(projects);
     }
 
@@ -119,7 +120,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
      * Replaces the contents of the item list to the content of the skill list.
      */
     public void setSkillToDisplay() {
-        displayType = "ski";
+        displayType = ItemUtil.SKILL_ALIAS;
         setItemsToDisplay(skills);
     }
 
@@ -127,7 +128,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
      * Replaces the contents of the item list to the content of the resume list.
      */
     public void setResumeToDisplay() {
-        displayType = "res";
+        displayType = ItemUtil.RESUME_ALIAS;
         setItemsToDisplay(resumes);
     }
 

--- a/src/main/java/seedu/address/model/VersionedResumeBook.java
+++ b/src/main/java/seedu/address/model/VersionedResumeBook.java
@@ -103,7 +103,7 @@ public class VersionedResumeBook extends ResumeBook {
      */
     public static class NoUndoableStateException extends RuntimeException {
         private NoUndoableStateException() {
-            super("Current state pointer at start of addressBookState list, unable to undo.");
+            super("Current state pointer at start of resumeBookState list, unable to undo.");
         }
     }
 
@@ -112,7 +112,7 @@ public class VersionedResumeBook extends ResumeBook {
      */
     public static class NoRedoableStateException extends RuntimeException {
         private NoRedoableStateException() {
-            super("Current state pointer at end of addressBookState list, unable to redo.");
+            super("Current state pointer at end of resumeBookState list, unable to redo.");
         }
     }
 }

--- a/src/main/java/seedu/address/model/item/Internship.java
+++ b/src/main/java/seedu/address/model/item/Internship.java
@@ -22,13 +22,13 @@ public class Internship extends Item {
     private String description;
 
     public Internship(Name name, String role, Time from, Time to, String description, Set<Tag> tags) {
-        this(name, role, from, to, description, tags, ItemUtil.yieldId("int"));
+        this(name, role, from, to, description, tags, ItemUtil.yieldId(ItemUtil.INTERNSHIP_ALIAS));
     }
 
     public Internship(Name name, String role, Time from, Time to, String description, Set<Tag> tags, int id) {
         super(name, id, tags);
         requireAllNonNull(role, from, to, description);
-        this.type = Type.generate("int");
+        this.type = Type.generate(ItemUtil.INTERNSHIP_ALIAS);
         this.role = role;
         this.from = from;
         this.to = to;

--- a/src/main/java/seedu/address/model/item/Project.java
+++ b/src/main/java/seedu/address/model/item/Project.java
@@ -22,13 +22,13 @@ public class Project extends Item {
     private String description;
 
     public Project(Name name, Time time, Website website, String description, Set<Tag> tags) {
-        this(name, time, website, description, tags, ItemUtil.yieldId("proj"));
+        this(name, time, website, description, tags, ItemUtil.yieldId(ItemUtil.PROJECT_ALIAS));
     }
 
     public Project(Name name, Time time, Website website, String description, Set<Tag> tags, int id) {
         super(name, id, tags);
         requireAllNonNull(time, website, description);
-        this.type = Type.generate("proj");
+        this.type = Type.generate(ItemUtil.PROJECT_ALIAS);
         this.time = time;
         this.website = website;
         this.description = description;

--- a/src/main/java/seedu/address/model/item/Resume.java
+++ b/src/main/java/seedu/address/model/item/Resume.java
@@ -22,12 +22,12 @@ public class Resume extends Item {
     private final TreeSet<Integer> skills = new TreeSet<>();
 
     public Resume(Name name, Set<Tag> tags) {
-        this(name, ItemUtil.yieldId("res"), tags);
+        this(name, ItemUtil.yieldId(ItemUtil.RESUME_ALIAS), tags);
     }
 
     public Resume(Name name, int id, Set<Tag> tags) {
         super(name, id, tags);
-        this.type = Type.generate("res");
+        this.type = Type.generate(ItemUtil.RESUME_ALIAS);
         // TODO: change Resume constructor to take in existing lists of internships, projects or skills
     }
 

--- a/src/main/java/seedu/address/model/item/Skill.java
+++ b/src/main/java/seedu/address/model/item/Skill.java
@@ -19,13 +19,13 @@ public class Skill extends Item {
     private Level level;
 
     public Skill(Name name, Level level, Set<Tag> tags) {
-        this(name, level, tags, ItemUtil.yieldId("ski"));
+        this(name, level, tags, ItemUtil.yieldId(ItemUtil.SKILL_ALIAS));
     }
 
     public Skill(Name name, Level level, Set<Tag> tags, int id) {
         super(name, id, tags);
         requireNonNull(level);
-        this.type = Type.generate("ski");
+        this.type = Type.generate(ItemUtil.SKILL_ALIAS);
         this.level = level;
     }
 

--- a/src/main/java/seedu/address/model/item/field/Type.java
+++ b/src/main/java/seedu/address/model/item/field/Type.java
@@ -38,4 +38,9 @@ public class Type {
             return "Not a valid type";
         }
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) || this.getAlias().equals(((Type) obj).getAlias());
+    }
 }

--- a/src/main/java/seedu/address/model/util/ItemUtil.java
+++ b/src/main/java/seedu/address/model/util/ItemUtil.java
@@ -7,6 +7,12 @@ import java.util.TreeMap;
  */
 public class ItemUtil {
 
+    public static final String INTERNSHIP_ALIAS = "int";
+    public static final String PROJECT_ALIAS = "proj";
+    public static final String RESUME_ALIAS = "res";
+    public static final String SKILL_ALIAS = "ski";
+
+
     private static TreeMap<String, Integer> idGenerator = new TreeMap<>();
 
     /**


### PR DESCRIPTION
The classes `Resume`, `Internship`, `Project`, and `Skill` have their aliases used quite often by other classes. It starts getting hard to track so I bundled them up in `ItemUtil` class (which is under the Model subpackage).

