### PR TITLE
Fix duplicate exceptions for EditCommand (+ messages)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/add/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/add/AddCommand.java
@@ -25,5 +25,5 @@ public abstract class AddCommand extends Command {
             + PREFIX_TAG + "tech";
 
     public static final String MESSAGE_SUCCESS = "New %1$s added";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the resume book";
 }

--- a/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditCommand.java
@@ -19,6 +19,9 @@ public abstract class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
+    // TODO: Refactor this into a nice message centre
+    public static final String MESSAGE_DUPLICATE_ITEM = "Item with the same name already exists in the resume book.";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the item identified "
             + "by the index number used in the displayed item list. "
             + "Existing values will be overwritten by the input values.\n"

--- a/src/main/java/seedu/address/logic/commands/edit/EditInternshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditInternshipCommand.java
@@ -71,6 +71,10 @@ public class EditInternshipCommand extends EditCommand {
 
         Internship editedInternship = createEditedInternship(toEdit, editInternshipDescriptor);
 
+        if (model.hasInternship(editedInternship)) {
+            throw new CommandException("An internship with the same name, role, and time already exists.");
+        }
+
         model.setInternship(toEdit, editedInternship);
         model.setInternshipToDisplay();
         model.commitResumeBook();

--- a/src/main/java/seedu/address/logic/commands/edit/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditProjectCommand.java
@@ -65,12 +65,16 @@ public class EditProjectCommand extends EditCommand {
 
         Project toEdit = model.getProjectByIndex(index);
 
-        Project editProject = createEditedProject(toEdit, editProjectDescriptor);
+        Project editedProject = createEditedProject(toEdit, editProjectDescriptor);
 
-        model.setProject(toEdit, editProject);
+        if (model.hasProject(editedProject)) {
+            throw new CommandException("A project with the same name and time already exists.");
+        }
+
+        model.setProject(toEdit, editedProject);
         model.setProjectToDisplay();
         model.commitResumeBook();
-        return new CommandResult(editProject.toString(), String.format(MESSAGE_EDIT_PROJECT_SUCCESS, editProject),
+        return new CommandResult(editedProject.toString(), String.format(MESSAGE_EDIT_PROJECT_SUCCESS, editedProject),
                 model.getDisplayType());
     }
 

--- a/src/main/java/seedu/address/logic/commands/edit/EditResumeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditResumeCommand.java
@@ -54,6 +54,10 @@ public class EditResumeCommand extends EditCommand {
 
         Resume editedResume = createEditedResume(toEdit, editResumeDescriptor);
 
+        if (model.hasResume(editedResume)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ITEM);
+        }
+
         model.setResume(toEdit, editedResume);
         model.setResumeToDisplay();
         model.commitResumeBook();

--- a/src/main/java/seedu/address/logic/commands/edit/EditSkillCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditSkillCommand.java
@@ -58,6 +58,10 @@ public class EditSkillCommand extends EditCommand {
 
         Skill editedSkill = createEditedSkill(toEdit, editSkillDescriptor);
 
+        if (model.hasSkill(editedSkill)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ITEM);
+        }
+
         model.setSkill(toEdit, editedSkill);
         model.setSkillToDisplay();
         model.commitResumeBook();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -76,6 +76,7 @@ public class ParserUtil {
         return new Phone(trimmedPhone);
     }
 
+    // TODO: BEAUTIFY THE EXCEPTION MESSAGE
     /**
      * Parses a {@code String level} into a {@code Level}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/Verifier.java
+++ b/src/main/java/seedu/address/logic/parser/Verifier.java
@@ -6,12 +6,12 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Validations for different input.
  */
 public class Verifier {
-    public static final int UNIVERSITY_MAX_LENGTH = 30;
+    public static final int UNIVERSITY_MAX_LENGTH = 100;
     public static final String UNIVERSITY_MESSAGE_CONSTRAINTS =
             "University should only contain alphanumeric characters and spaces, and it should not be blank";
     public static final String UNIVERSITY_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public static final int MAJOR_MAX_LENGTH = 30;
+    public static final int MAJOR_MAX_LENGTH = 100;
     public static final String MAJOR_MESSAGE_CONSTRAINTS =
             "Major should only contain alphanumeric characters and spaces, and it should not be blank";
     public static final String MAJOR_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";


### PR DESCRIPTION
Adding an item that counts as a duplicate (varied criteria) will not properly show a warning message to user.