### PR TITLE
Implement Tag Pull

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -469,7 +469,7 @@ Pull the internship, project and skill items with the specified tag(s) into a re
 `tagpull INDEX [#/ TAG]`
 ****
 
-This command does not remove items from the resume and will add items on top of existing items. 
+This command does not remove items from the resume and will add items on top of existing items.
 
 Examples:
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -432,6 +432,8 @@ Edits the resume to contain the items specified in the command.
 ****
 `redit RESUME_INDEX TYPE/ [ITEM_INDEX...] [MORE_TYPE/ [ITEM_INDEX...]]`
 ****
+[TIP]
+If you find it a hassle to manually enter items into the resume, you can consider using <<Pulling tagged items into the resume: `tagpull`, tagpull>>!
 
 * For each `TYPE`, existing items will be updated to the input items.
 * You can add multiple items of a certain type to a resume by chaining
@@ -457,8 +459,25 @@ This command modifies the resume at index 1. It changes the resume to contain in
 
 image::ReditWantSomeThings.png[][WantSomeThings,442,337]
 
-===== Tag Pull
-(To be implemented) Edits the resume specified at that index to contain all items of the specified tag.
+=== Pulling tagged items into the resume: `tagpull`
+
+Pull the internship, project and skill items with the specified tag(s) into a resume.
+
+**Format:**
+
+****
+`tagpull INDEX [#/ TAG]`
+****
+
+This command does not remove items from the resume and will add items on top of existing items. 
+
+Examples:
+
+* `tagpull 1 #/ tech` +
+This command modifies the resume at index 1. It will find all the internship, project, and skill items with the tag `tech` and adds it into the resume.
+
+* `tagpull 2 #/ tech frontend` +
+This command modifies the resume at index 2. It will find all the internship, project, and skill items which has either the tag `tech` or `frontend` and adds it into the resume.
 
 === Undo a command: `undo`
 

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -6,11 +6,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
@@ -19,11 +16,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.results.CommandResult;
 import seedu.address.logic.commands.results.ResumeEditCommandResult;
 import seedu.address.model.Model;
-import seedu.address.model.item.Internship;
-import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
-import seedu.address.model.item.Skill;
-import seedu.address.model.tag.Tag;
 
 /**
  * Edits the content of a Resume.
@@ -43,21 +36,16 @@ public class ResumeEditCommand extends Command {
             + PREFIX_PROJECT + " 1 ";
 
     protected final Index index;
-    protected final Set<Tag> tagList;
-    protected final boolean isTagPull;
     protected final Optional<List<Integer>> internshipIndices;
     protected final Optional<List<Integer>> projectIndices;
     protected final Optional<List<Integer>> skillIndices;
 
     public ResumeEditCommand(Index index, Optional<List<Integer>> internshipIndices,
-                             Optional<List<Integer>> projectIndices, Optional<List<Integer>> skillIndices,
-                             Set<Tag> tagList, boolean isTagPull) {
+                             Optional<List<Integer>> projectIndices, Optional<List<Integer>> skillIndices) {
         this.index = index;
         this.internshipIndices = internshipIndices;
         this.projectIndices = projectIndices;
         this.skillIndices = skillIndices;
-        this.tagList = tagList;
-        this.isTagPull = isTagPull;
     }
 
     @Override
@@ -76,35 +64,8 @@ public class ResumeEditCommand extends Command {
         List<Integer> projectIds = toEdit.getProjectIds();
         List<Integer> skillIds = toEdit.getSkillIds();
 
-        // Temporary implementation: Either you do a tag pull, or you do normally:
-        if (isTagPull) {
-            List<List<Integer>> listOfLists = tagPull(internshipIds, projectIds, skillIds, model);
-            internshipIds = listOfLists.get(0);
-            projectIds = listOfLists.get(1);
-            skillIds = listOfLists.get(2);
-        } else {
-            List<List<Integer>> listOfLists = normalImplementation(internshipIds, projectIds, skillIds, model);
-            internshipIds = listOfLists.get(0);
-            projectIds = listOfLists.get(1);
-            skillIds = listOfLists.get(2);
-        }
-
-
-
-        Resume editedResume = new Resume(toEdit.getName(), toEdit.getId(), toEdit.getTags());
-        model.editResume(editedResume, internshipIds, projectIds, skillIds);
-        model.setResume(toEdit, editedResume);
-        model.setResumeToDisplay();
-        model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
-        model.commitResumeBook();
-        return new ResumeEditCommandResult(editedResume.toString(), "Resume is updated", model.getDisplayType());
-    }
-
-    private List<List<Integer>> normalImplementation(List<Integer> internshipIds, List<Integer> projectIds,
-                                                    List<Integer> skillIds, Model model) {
         // If any of the indices are present (user keys in the prefix), then use what the user uses
         // Else, use the one currently being used by the resume
-
         if (internshipIndices.isPresent()) {
             internshipIds = internshipIndices
                     .get()
@@ -131,41 +92,15 @@ public class ResumeEditCommand extends Command {
                     .map(x -> model.getSkillByIndex(Index.fromOneBased(x)).getId())
                     .collect(Collectors.toList());
         }
-        List<List<Integer>> newList = new ArrayList<>();
-        newList.add(internshipIds);
-        newList.add(projectIds);
-        newList.add(skillIds);
-        return newList;
-    }
 
-    private List<List<Integer>> tagPull(List<Integer> internshipIds, List<Integer> projectIds, List<Integer> skillIds,
-                                      Model model) {
-        List<List<Integer>> newList = new ArrayList<>();
-        internshipIds = tagList
-                .stream()
-                .map(model::getInternshipsByTag)
-                .flatMap(Collection::stream)
-                .map(Internship::getId)
-                .collect(Collectors.toList());
-
-        projectIds = tagList
-                .stream()
-                .map(model::getProjectsByTag)
-                .flatMap(Collection::stream)
-                .map(Project::getId)
-                .collect(Collectors.toList());
-
-        skillIds = tagList
-                .stream()
-                .map(model::getSkillsByTag)
-                .flatMap(Collection::stream)
-                .map(Skill::getId)
-                .collect(Collectors.toList());
-
-        newList.add(internshipIds);
-        newList.add(projectIds);
-        newList.add(skillIds);
-        return newList;
+        Resume editedResume = new Resume(toEdit.getName(), toEdit.getId(), toEdit.getTags());
+        model.editResume(editedResume, internshipIds, projectIds, skillIds);
+        model.setResume(toEdit, editedResume);
+        model.setResumeToDisplay();
+        model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
+        model.commitResumeBook();
+        return new ResumeEditCommandResult(editedResume.toString(), "Resume is updated",
+                model.getDisplayType());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -18,6 +19,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.results.CommandResult;
 import seedu.address.logic.commands.results.ResumeEditCommandResult;
 import seedu.address.model.Model;
+import seedu.address.model.item.Internship;
 import seedu.address.model.item.Resume;
 import seedu.address.model.tag.Tag;
 
@@ -137,6 +139,15 @@ public class ResumeEditCommand extends Command {
     private List<List<Integer>> tagPull(List<Integer> internshipIds, List<Integer> projectIds, List<Integer> skillIds,
                                       Model model) {
         List<List<Integer>> newList = new ArrayList<>();
+        internshipIds = tagList
+                .stream()
+                .map(model::getInternshipsByTag)
+                .flatMap(Collection::stream)
+                .map(Internship::getId)
+                .collect(Collectors.toList());
+        newList.add(internshipIds);
+        newList.add(projectIds);
+        newList.add(skillIds);
         return newList;
     }
 

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -20,7 +20,9 @@ import seedu.address.logic.commands.results.CommandResult;
 import seedu.address.logic.commands.results.ResumeEditCommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.item.Internship;
+import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
+import seedu.address.model.item.Skill;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -145,6 +147,21 @@ public class ResumeEditCommand extends Command {
                 .flatMap(Collection::stream)
                 .map(Internship::getId)
                 .collect(Collectors.toList());
+
+        projectIds = tagList
+                .stream()
+                .map(model::getProjectsByTag)
+                .flatMap(Collection::stream)
+                .map(Project::getId)
+                .collect(Collectors.toList());
+
+        skillIds = tagList
+                .stream()
+                .map(model::getSkillsByTag)
+                .flatMap(Collection::stream)
+                .map(Skill::getId)
+                .collect(Collectors.toList());
+
         newList.add(internshipIds);
         newList.add(projectIds);
         newList.add(skillIds);

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
@@ -17,6 +18,7 @@ import seedu.address.logic.commands.results.CommandResult;
 import seedu.address.logic.commands.results.ResumeEditCommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.item.Resume;
+import seedu.address.model.tag.Tag;
 
 /**
  * Edits the content of a Resume.
@@ -36,16 +38,19 @@ public class ResumeEditCommand extends Command {
             + PREFIX_PROJECT + " 1 ";
 
     protected final Index index;
+    protected final Set<Tag> tagList;
     protected final Optional<List<Integer>> internshipIndices;
     protected final Optional<List<Integer>> projectIndices;
     protected final Optional<List<Integer>> skillIndices;
 
     public ResumeEditCommand(Index index, Optional<List<Integer>> internshipIndices,
-                             Optional<List<Integer>> projectIndices, Optional<List<Integer>> skillIndices) {
+                             Optional<List<Integer>> projectIndices, Optional<List<Integer>> skillIndices,
+                             Set<Tag> tagList) {
         this.index = index;
         this.internshipIndices = internshipIndices;
         this.projectIndices = projectIndices;
         this.skillIndices = skillIndices;
+        this.tagList = tagList;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -97,7 +97,7 @@ public class ResumeEditCommand extends Command {
         model.setResumeToDisplay();
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
         model.commitResumeBook();
-        return new ResumeEditCommandResult(toEdit.toString(), "Resume is updated", model.getDisplayType());
+        return new ResumeEditCommandResult(editedResume.toString(), "Resume is updated", model.getDisplayType());
     }
 
     private List<List<Integer>> normalImplementation(List<Integer> internshipIds, List<Integer> projectIds,

--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -73,9 +74,15 @@ public class ResumeEditCommand extends Command {
 
         // Temporary implementation: Either you do a tag pull, or you do normally:
         if (isTagPull) {
-            normalImplementation(internshipIds, projectIds, skillIds, model);
+            List<List<Integer>> listOfLists = tagPull(internshipIds, projectIds, skillIds, model);
+            internshipIds = listOfLists.get(0);
+            projectIds = listOfLists.get(1);
+            skillIds = listOfLists.get(2);
         } else {
-            tagPull(internshipIds, projectIds, skillIds, model);
+            List<List<Integer>> listOfLists = normalImplementation(internshipIds, projectIds, skillIds, model);
+            internshipIds = listOfLists.get(0);
+            projectIds = listOfLists.get(1);
+            skillIds = listOfLists.get(2);
         }
 
 
@@ -89,8 +96,8 @@ public class ResumeEditCommand extends Command {
         return new ResumeEditCommandResult(toEdit.toString(), "Resume is updated", model.getDisplayType());
     }
 
-    private void normalImplementation(List<Integer> internshipIds, List<Integer> projectIds, List<Integer> skillIds,
-                                      Model model) {
+    private List<List<Integer>> normalImplementation(List<Integer> internshipIds, List<Integer> projectIds,
+                                                    List<Integer> skillIds, Model model) {
         // If any of the indices are present (user keys in the prefix), then use what the user uses
         // Else, use the one currently being used by the resume
 
@@ -120,11 +127,17 @@ public class ResumeEditCommand extends Command {
                     .map(x -> model.getSkillByIndex(Index.fromOneBased(x)).getId())
                     .collect(Collectors.toList());
         }
+        List<List<Integer>> newList = new ArrayList<>();
+        newList.add(internshipIds);
+        newList.add(projectIds);
+        newList.add(skillIds);
+        return newList;
     }
 
-    private void tagPull(List<Integer> internshipIds, List<Integer> projectIds, List<Integer> skillIds,
+    private List<List<Integer>> tagPull(List<Integer> internshipIds, List<Integer> projectIds, List<Integer> skillIds,
                                       Model model) {
-
+        List<List<Integer>> newList = new ArrayList<>();
+        return newList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/TagPullCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPullCommand.java
@@ -30,9 +30,9 @@ public class TagPullCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Pulls all the items with the desired tag into the "
             + "resume in the application with the specified index.\n"
-            + "Existing values will be added on top the new items to be added"
+            + "Existing values will be added on top the new items to be added.\n"
             + "Parameters: INDEX "
-            + "[#/ TAG}\n"
+            + "[#/ TAG]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + " tech";
 

--- a/src/main/java/seedu/address/logic/commands/TagPullCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPullCommand.java
@@ -1,0 +1,112 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.results.CommandResult;
+import seedu.address.logic.commands.results.ResumeEditCommandResult;
+import seedu.address.logic.commands.results.TagPullCommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.item.Internship;
+import seedu.address.model.item.Project;
+import seedu.address.model.item.Resume;
+import seedu.address.model.item.Skill;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Edits the content of a Resume.
+ */
+public class TagPullCommand extends Command {
+    public static final String COMMAND_WORD = "tagpull";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Pulls all the items with the desired tag into the "
+            + "resume in the application with the specified index.\n"
+            + "Existing values will be added on top the new items to be added"
+            + "Parameters: INDEX "
+            + "[#/ TAG}\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_TAG + " tech";
+
+    protected final Index index;
+    protected final Set<Tag> tagList;
+
+    public TagPullCommand(Index index, Set<Tag> tagList) {
+        this.index = index;
+        this.tagList = tagList;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (index.getZeroBased() >= model.getResumeSize()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_INDEX);
+        }
+
+        Resume toEdit = model.getResumeByIndex(index);
+
+        // The item IDs of specified resume
+        List<Integer> currInternshipIds = toEdit.getInternshipIds();
+        List<Integer> currProjectIds = toEdit.getProjectIds();
+        List<Integer> currSkillIds = toEdit.getSkillIds();
+
+        // The item IDs with the desired tags
+        List<Integer> pulledInternshipIds = tagList
+                .stream()
+                .map(model::getInternshipsByTag)
+                .flatMap(Collection::stream)
+                .map(Internship::getId)
+                .collect(Collectors.toList());
+
+        List<Integer> pulledProjectIds = tagList
+                .stream()
+                .map(model::getProjectsByTag)
+                .flatMap(Collection::stream)
+                .map(Project::getId)
+                .collect(Collectors.toList());
+
+        List<Integer> pulledSkillIds = tagList
+                .stream()
+                .map(model::getSkillsByTag)
+                .flatMap(Collection::stream)
+                .map(Skill::getId)
+                .collect(Collectors.toList());
+
+        // Concatenate both sets of items as we are adding on top
+        List<Integer> internshipIds = Stream
+                .concat(currInternshipIds.stream(), pulledInternshipIds.stream())
+                .collect(Collectors.toList());
+
+        List<Integer> projectIds = Stream
+                .concat(currProjectIds.stream(), pulledProjectIds.stream())
+                .collect(Collectors.toList());
+
+        List<Integer> skillIds = Stream
+                .concat(currSkillIds.stream(), pulledSkillIds.stream())
+                .collect(Collectors.toList());
+
+        Resume editedResume = new Resume(toEdit.getName(), toEdit.getId(), toEdit.getTags());
+        model.editResume(editedResume, internshipIds, projectIds, skillIds);
+        model.setResume(toEdit, editedResume);
+        model.setResumeToDisplay();
+        model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
+        model.commitResumeBook();
+        return new TagPullCommandResult(editedResume.toString(), "Tag Pull is successful!",
+                model.getDisplayType());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/TagPullCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPullCommand.java
@@ -1,16 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ITEMS;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,7 +14,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.results.CommandResult;
-import seedu.address.logic.commands.results.ResumeEditCommandResult;
 import seedu.address.logic.commands.results.TagPullCommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.item.Internship;
@@ -90,14 +84,17 @@ public class TagPullCommand extends Command {
         // Concatenate both sets of items as we are adding on top
         List<Integer> internshipIds = Stream
                 .concat(currInternshipIds.stream(), pulledInternshipIds.stream())
+                .distinct()
                 .collect(Collectors.toList());
 
         List<Integer> projectIds = Stream
                 .concat(currProjectIds.stream(), pulledProjectIds.stream())
+                .distinct()
                 .collect(Collectors.toList());
 
         List<Integer> skillIds = Stream
                 .concat(currSkillIds.stream(), pulledSkillIds.stream())
+                .distinct()
                 .collect(Collectors.toList());
 
         Resume editedResume = new Resume(toEdit.getName(), toEdit.getId(), toEdit.getTags());

--- a/src/main/java/seedu/address/logic/commands/TagPullCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPullCommand.java
@@ -59,6 +59,10 @@ public class TagPullCommand extends Command {
         List<Integer> currProjectIds = toEdit.getProjectIds();
         List<Integer> currSkillIds = toEdit.getSkillIds();
 
+        int internshipCountBefore = currInternshipIds.size();
+        int projectCountBefore = currProjectIds.size();
+        int skillCountBefore = currSkillIds.size();
+
         // The item IDs with the desired tags
         List<Integer> pulledInternshipIds = tagList
                 .stream()
@@ -82,28 +86,40 @@ public class TagPullCommand extends Command {
                 .collect(Collectors.toList());
 
         // Concatenate both sets of items as we are adding on top
-        List<Integer> internshipIds = Stream
+        List<Integer> newInternshipIds = Stream
                 .concat(currInternshipIds.stream(), pulledInternshipIds.stream())
                 .distinct()
                 .collect(Collectors.toList());
 
-        List<Integer> projectIds = Stream
+        List<Integer> newProjectIds = Stream
                 .concat(currProjectIds.stream(), pulledProjectIds.stream())
                 .distinct()
                 .collect(Collectors.toList());
 
-        List<Integer> skillIds = Stream
+        List<Integer> newSkillIds = Stream
                 .concat(currSkillIds.stream(), pulledSkillIds.stream())
                 .distinct()
                 .collect(Collectors.toList());
 
+        int internshipCountAfter = newInternshipIds.size();
+        int projectCountAfter = newProjectIds.size();
+        int skillCountAfter = newSkillIds.size();
+
         Resume editedResume = new Resume(toEdit.getName(), toEdit.getId(), toEdit.getTags());
-        model.editResume(editedResume, internshipIds, projectIds, skillIds);
+        model.editResume(editedResume, newInternshipIds, newProjectIds, newSkillIds);
         model.setResume(toEdit, editedResume);
         model.setResumeToDisplay();
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
         model.commitResumeBook();
-        return new TagPullCommandResult(editedResume.toString(), "Tag Pull is successful!",
+
+        String feedbackToUser = new StringBuilder()
+                .append("Items pulled:\n")
+                .append(internshipCountAfter - internshipCountBefore).append(" internship(s), ")
+                .append(projectCountAfter - projectCountBefore).append(" project(s), ")
+                .append(skillCountAfter - skillCountBefore).append(" skill(s).")
+                .toString();
+
+        return new TagPullCommandResult(editedResume.toString(), feedbackToUser,
                 model.getDisplayType());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/results/TagPullCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/results/TagPullCommandResult.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands.results;
+
+/**
+ * Represents the result of the TagPull command execution.
+ */
+public class TagPullCommandResult extends CommandResult {
+
+    /**
+     * Constructs a {@code TagPullCommandResult} with the specified {@code dataToUser}, {@code feedbackToUser}, and
+     * {@code displayType}.
+     * @param dataToUser data to show user.
+     * @param feedbackToUser feedback to user.
+     * @param displayType the alias of the item type.
+     */
+    public TagPullCommandResult(String dataToUser, String feedbackToUser, String displayType) {
+        super(dataToUser, feedbackToUser, displayType);
+        super.isShowPreview = false;
+        super.isGenerate = false;
+        super.isShowHelp = false;
+        super.isExit = false;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ResumeEditCommand;
 import seedu.address.logic.commands.ResumePreviewCommand;
+import seedu.address.logic.commands.TagPullCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.add.AddCommand;
 import seedu.address.logic.commands.delete.DeleteCommand;
@@ -82,8 +83,13 @@ public class ResumeBookParser {
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
 
+        //-----------------Resume Editing-----------------------
+
         case ResumeEditCommand.COMMAND_WORD:
             return new ResumeEditCommandParser().parse(arguments);
+
+        case TagPullCommand.COMMAND_WORD:
+            return new TagPullCommandParser().parse(arguments);
 
         //-----------------Other commands-----------------------
 

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -33,6 +33,7 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_INTERNSHIP, PREFIX_SKILL, PREFIX_PROJECT, PREFIX_TAG);
         Index index;
         Set<Tag> tagList;
+        boolean isTagPull;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -42,6 +43,13 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
         }
         tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        if (tagList.isEmpty()) {
+            // Use the internship indices thingy
+            isTagPull = false;
+        } else {
+            isTagPull = true;
+        }
+
         // Optional.empty() denotes non-existence, "" denotes that no argument specified, else some arguments specified
         Optional<List<Integer>> internshipIndices = ParserUtil.parseReditItemIndices(
                 argMultimap.getValue(PREFIX_INTERNSHIP).orElse(null));
@@ -50,6 +58,6 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
         Optional<List<Integer>> skillsIndices = ParserUtil.parseReditItemIndices(
                 argMultimap.getValue(PREFIX_SKILL).orElse(null));
 
-        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices, tagList);
+        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices, tagList, isTagPull);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -5,16 +5,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ResumeEditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new {@code ResumeEditCommand} object

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -9,10 +9,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ResumeEditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new {@code ResumeEditCommand} object
@@ -30,6 +32,7 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_INTERNSHIP, PREFIX_SKILL, PREFIX_PROJECT, PREFIX_TAG);
         Index index;
+        Set<Tag> tagList;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
@@ -37,6 +40,7 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResumeEditCommand.MESSAGE_USAGE),
                     pe);
         }
+        tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         // Optional.empty() denotes non-existence, "" denotes that no argument specified, else some arguments specified
         Optional<List<Integer>> internshipIndices = ParserUtil.parseReditItemIndices(
@@ -46,7 +50,6 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
         Optional<List<Integer>> skillsIndices = ParserUtil.parseReditItemIndices(
                 argMultimap.getValue(PREFIX_SKILL).orElse(null));
 
-        // Will assume correct input for now
-        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices);
+        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices, tagList);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -30,24 +30,14 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
     public ResumeEditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_INTERNSHIP, PREFIX_SKILL, PREFIX_PROJECT, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_INTERNSHIP, PREFIX_SKILL, PREFIX_PROJECT);
         Index index;
-        Set<Tag> tagList;
-        boolean isTagPull;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResumeEditCommand.MESSAGE_USAGE),
                     pe);
-        }
-        tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
-        if (tagList.isEmpty()) {
-            // Use the internship indices thingy
-            isTagPull = false;
-        } else {
-            isTagPull = true;
         }
 
         // Optional.empty() denotes non-existence, "" denotes that no argument specified, else some arguments specified
@@ -58,6 +48,6 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
         Optional<List<Integer>> skillsIndices = ParserUtil.parseReditItemIndices(
                 argMultimap.getValue(PREFIX_SKILL).orElse(null));
 
-        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices, tagList, isTagPull);
+        return new ResumeEditCommand(index, internshipIndices, projectsIndices, skillsIndices);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.ResumeEditCommand;
 import seedu.address.logic.commands.TagPullCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
@@ -29,13 +28,12 @@ public class TagPullCommandParser implements Parser<TagPullCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_TAG);
         Index index;
         Set<Tag> tagList;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResumeEditCommand.MESSAGE_USAGE),
-                    pe);
+        if (!argMultimap.getValue(PREFIX_TAG).isPresent() || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    TagPullCommand.MESSAGE_USAGE));
         }
+
+        index = ParserUtil.parseIndex(argMultimap.getPreamble());
         tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         return new TagPullCommand(index, tagList);

--- a/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ResumeEditCommand;
+import seedu.address.logic.commands.TagPullCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new {@code ResumeEditCommand} object
+ */
+public class TagPullCommandParser implements Parser<TagPullCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ResumeEditCommand
+     * and returns an ResumeEditCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public TagPullCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+        Index index;
+        Set<Tag> tagList;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResumeEditCommand.MESSAGE_USAGE),
+                    pe);
+        }
+        tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        return new TagPullCommand(index, tagList);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -14,13 +13,13 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new {@code ResumeEditCommand} object
+ * Parses input arguments and creates a new {@code TagPullCommand} object
  */
 public class TagPullCommandParser implements Parser<TagPullCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the ResumeEditCommand
-     * and returns an ResumeEditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the TagPullCommand
+     * and returns an TagPullCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     @Override

--- a/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagPullCommandParser.java
@@ -3,13 +3,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -172,6 +172,8 @@ public interface Model {
      */
     Project getProjectById(int id);
 
+    List<Project> getProjectsByTag(Tag tag);
+
     /**
      * Return the size of the project list.
      */
@@ -223,6 +225,8 @@ public interface Model {
      * @return Skill item with {@code id}
      */
     Skill getSkillById(int id);
+
+    List<Skill> getSkillsByTag(Tag tag);
 
     /**
      * Return the size of the skill list.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -13,6 +13,7 @@ import seedu.address.model.item.Person;
 import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
 import seedu.address.model.item.Skill;
+import seedu.address.model.tag.Tag;
 
 /**
  * The API of the Model component.
@@ -116,6 +117,8 @@ public interface Model {
      * @return Internship item with {@code id}
      */
     Internship getInternshipById(int id);
+
+    List<Internship> getInternshipsByTag(Tag tag);
 
     /**
      * Return the size of the internship list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -19,6 +19,7 @@ import seedu.address.model.item.Person;
 import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
 import seedu.address.model.item.Skill;
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -140,6 +141,11 @@ public class ModelManager implements Model {
     @Override
     public Internship getInternshipByIndex(Index index) {
         return versionedResumeBook.getInternshipByIndex(index);
+    }
+
+    @Override
+    public List<Internship> getInternshipsByTag(Tag tag) {
+        return versionedResumeBook.getInternshipsByTag(tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -210,7 +210,7 @@ public class ModelManager implements Model {
 
     @Override
     public List<Project> getProjectsByTag(Tag tag) {
-        return versionedResumeBook.getProjectsbyTag(tag);
+        return versionedResumeBook.getProjectsByTag(tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -144,11 +144,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public List<Internship> getInternshipsByTag(Tag tag) {
-        return versionedResumeBook.getInternshipsByTag(tag);
-    }
-
-    @Override
     public boolean hasInternshipId(int id) {
         return versionedResumeBook.hasInternshipId(id);
     }
@@ -156,6 +151,11 @@ public class ModelManager implements Model {
     @Override
     public Internship getInternshipById(int id) {
         return versionedResumeBook.getInternshipById(id);
+    }
+
+    @Override
+    public List<Internship> getInternshipsByTag(Tag tag) {
+        return versionedResumeBook.getInternshipsByTag(tag);
     }
 
     @Override
@@ -209,6 +209,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public List<Project> getProjectsByTag(Tag tag) {
+        return versionedResumeBook.getProjectsbyTag(tag);
+    }
+
+    @Override
     public int getProjectSize() {
         return versionedResumeBook.getProjectSize();
     }
@@ -256,6 +261,11 @@ public class ModelManager implements Model {
     @Override
     public Skill getSkillById(int id) {
         return versionedResumeBook.getSkillById(id);
+    }
+
+    @Override
+    public List<Skill> getSkillsByTag(Tag tag) {
+        return versionedResumeBook.getSkillsByTag(tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyResumeBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyResumeBook.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.util.List;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.item.Internship;
@@ -9,6 +11,7 @@ import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
 import seedu.address.model.item.Skill;
 import seedu.address.model.item.UniqueItemList;
+import seedu.address.model.tag.Tag;
 
 /**
  * Unmodifiable view of a resume book
@@ -62,6 +65,13 @@ public interface ReadOnlyResumeBook {
      */
     Internship getInternshipByIndex(Index index);
 
+    /**
+     * Returns a list of Internship which is tagged with {@code tag}.
+     * @param tag the {@code tag} which is expected in the Internship item.
+     * @return List of Internship tagged with {@code tag}.
+     */
+    List<Internship> getInternshipsByTag(Tag tag);
+
     boolean hasInternshipId(int id);
 
     /**
@@ -83,6 +93,13 @@ public interface ReadOnlyResumeBook {
      */
     Project getProjectByIndex(Index index);
 
+    /**
+     * Returns a list of Project which is tagged with {@code tag}.
+     * @param tag the {@code tag} which is expected in the Project item.
+     * @return List of Project tagged with {@code tag}.
+     */
+    List<Project> getProjectsByTag(Tag tag);
+
     boolean hasProjectId(int id);
 
     /**
@@ -103,6 +120,13 @@ public interface ReadOnlyResumeBook {
      * @return Skill item at {@code index}
      */
     Skill getSkillByIndex(Index index);
+
+    /**
+     * Returns a list of Skill which is tagged with {@code tag}.
+     * @param tag the {@code tag} which is expected in the Skill item.
+     * @return List of Skill tagged with {@code tag}.
+     */
+    List<Skill> getSkillsByTag(Tag tag);
 
     boolean hasSkillId(int id);
 

--- a/src/main/java/seedu/address/model/ResumeBook.java
+++ b/src/main/java/seedu/address/model/ResumeBook.java
@@ -246,7 +246,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
         return internships.asUnmodifiableObservableList().get(index.getZeroBased());
     }
 
-    // TODO: Override?
+    @Override
     public List<Internship> getInternshipsByTag(Tag tag) {
         return internships
             .getItemList()
@@ -334,8 +334,8 @@ public class ResumeBook implements ReadOnlyResumeBook {
         return projects.asUnmodifiableObservableList().get(index.getZeroBased());
     }
 
-    // TODO: Override?
-    public List<Project> getProjectsbyTag(Tag tag) {
+    @Override
+    public List<Project> getProjectsByTag(Tag tag) {
         return projects
             .getItemList()
             .stream()
@@ -420,7 +420,7 @@ public class ResumeBook implements ReadOnlyResumeBook {
         return skills.asUnmodifiableObservableList().get(index.getZeroBased());
     }
 
-    // TODO: Override?
+    @Override
     public List<Skill> getSkillsByTag(Tag tag) {
         return skills
             .getItemList()

--- a/src/main/java/seedu/address/model/ResumeBook.java
+++ b/src/main/java/seedu/address/model/ResumeBook.java
@@ -248,15 +248,15 @@ public class ResumeBook implements ReadOnlyResumeBook {
 
     // TODO: Override?
     public List<Internship> getInternshipsByTag(Tag tag) {
-        List<Internship> filteredListByTag = internships
-                .getItemList()
-                .stream()
-                .distinct()
-                .filter(x -> x.hasTag(tag))
-                .map(x -> (Internship) x)
-                .collect(Collectors.toList());
-        return filteredListByTag;
+        return internships
+            .getItemList()
+            .stream()
+            .distinct()
+            .filter(x -> x.hasTag(tag))
+            .map(x -> (Internship) x)
+            .collect(Collectors.toList());
     }
+
 
 
     @Override
@@ -334,6 +334,17 @@ public class ResumeBook implements ReadOnlyResumeBook {
         return projects.asUnmodifiableObservableList().get(index.getZeroBased());
     }
 
+    // TODO: Override?
+    public List<Project> getProjectsbyTag(Tag tag) {
+        return projects
+            .getItemList()
+            .stream()
+            .distinct()
+            .filter(x -> x.hasTag(tag))
+            .map(x -> (Project) x)
+            .collect(Collectors.toList());
+    }
+
     @Override
     public boolean hasProjectId(int id) {
         for (Project item : projects) {
@@ -407,6 +418,17 @@ public class ResumeBook implements ReadOnlyResumeBook {
     @Override
     public Skill getSkillByIndex(Index index) {
         return skills.asUnmodifiableObservableList().get(index.getZeroBased());
+    }
+
+    // TODO: Override?
+    public List<Skill> getSkillsByTag(Tag tag) {
+        return skills
+            .getItemList()
+            .stream()
+            .distinct()
+            .filter(x -> x.hasTag(tag))
+            .map(x -> (Skill) x)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ResumeBook.java
+++ b/src/main/java/seedu/address/model/ResumeBook.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
@@ -20,6 +21,7 @@ import seedu.address.model.item.field.Github;
 import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Phone;
 import seedu.address.model.item.field.Time;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.util.ItemUtil;
 
 /**
@@ -243,6 +245,19 @@ public class ResumeBook implements ReadOnlyResumeBook {
     public Internship getInternshipByIndex(Index index) {
         return internships.asUnmodifiableObservableList().get(index.getZeroBased());
     }
+
+    // TODO: Override?
+    public List<Internship> getInternshipsByTag(Tag tag) {
+        List<Internship> filteredListByTag = internships
+                .getItemList()
+                .stream()
+                .distinct()
+                .filter(x -> x.hasTag(tag))
+                .map(x -> (Internship) x)
+                .collect(Collectors.toList());
+        return filteredListByTag;
+    }
+
 
     @Override
     public boolean hasInternshipId(int id) {

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -77,6 +77,10 @@ public abstract class Item {
         return Collections.unmodifiableSet(tags);
     }
 
+    public boolean hasTag(Tag tag) {
+        return tags.contains(tag);
+    }
+
     /**
      * Returns true if both items have the same name and are of the same type.
      * This defines a weaker notion of equality between two items.

--- a/src/test/java/seedu/address/model/ResumeBookTest.java
+++ b/src/test/java/seedu/address/model/ResumeBookTest.java
@@ -24,6 +24,7 @@ package seedu.address.model;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -43,6 +44,7 @@ import seedu.address.model.item.field.Name;
 import seedu.address.model.item.field.Phone;
 import seedu.address.model.item.field.Time;
 import seedu.address.model.item.field.Website;
+import seedu.address.model.tag.Tag;
 
 public class ResumeBookTest {
     /*
@@ -180,6 +182,11 @@ public class ResumeBookTest {
         }
 
         @Override
+        public List<Internship> getInternshipsByTag(Tag tag) {
+            return null;
+        }
+
+        @Override
         public Internship getInternshipById(int id) {
             return new Internship(new Name("Company 1"), "Software Engineer", new Time("02-2019"),
                     new Time("05-2020"), "I did nothing", new HashSet<>());
@@ -192,6 +199,11 @@ public class ResumeBookTest {
         }
 
         @Override
+        public List<Project> getProjectsByTag(Tag tag) {
+            return null;
+        }
+
+        @Override
         public Project getProjectById(int id) {
             return new Project(new Name("Project 1"), new Time("01-2020"), new Website("www.website.com"),
                     "I did nothing", new HashSet<>());
@@ -200,6 +212,11 @@ public class ResumeBookTest {
         @Override
         public Skill getSkillByIndex(Index index) {
             return new Skill(new Name("Useless skill 1"), Level.ADVANCED, new HashSet<>(), -1);
+        }
+
+        @Override
+        public List<Skill> getSkillsByTag(Tag tag) {
+            return null;
         }
 
         @Override

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -16,6 +16,7 @@ import seedu.address.model.item.Person;
 import seedu.address.model.item.Project;
 import seedu.address.model.item.Resume;
 import seedu.address.model.item.Skill;
+import seedu.address.model.tag.Tag;
 
 /**
  * A default model stub that have all of the methods failing.
@@ -107,6 +108,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public List<Internship> getInternshipsByTag(Tag tag) {
+        return null;
+    }
+
+    @Override
     public int getInternshipSize() {
         return 0;
     }
@@ -147,6 +153,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public List<Project> getProjectsByTag(Tag tag) {
+        return null;
+    }
+
+    @Override
     public int getProjectSize() {
         return 0;
     }
@@ -183,6 +194,11 @@ public class ModelStub implements Model {
 
     @Override
     public Skill getSkillById(int id) {
+        return null;
+    }
+
+    @Override
+    public List<Skill> getSkillsByTag(Tag tag) {
         return null;
     }
 


### PR DESCRIPTION
Implemented a new `tagpull` command which adds on top of the items in the resume with new items of a specified tags. It can work with multiple tags: `tagpull 1 #/ frontend #/ backend`.

Separated the implementation of tagpull from redit due to slightly different expected behaviour. 


--obsolete--
Considerations:
* A separate Tag Pull command instead of combining it with `redit`
* Disallow using `redit` together with the Tag Pull.
* Tag Pull should add on top of whatever you have in the resume

Name for command: `rpull`, `pull`, `tagpull`? 