### PR TITLE
Add ResumeEditCommandParserTest

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,6 +33,8 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_REDIT_ITEM_INDEX = "Index provided for one of the items is not" +
+            " a non-zero unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -223,10 +225,17 @@ public class ParserUtil {
             // TODO: Investigate how this can be combined with the else block
             return Optional.of(new ArrayList<>());
         } else {
-            List<Integer> mappedIndices = Arrays.stream(indices.split("\\s+"))
-                    .map(Integer::parseInt)
-                    .collect(Collectors.toList());
+            boolean isValidIndices = Arrays
+                    .stream(indices.split("\\s+"))
+                    .allMatch(StringUtil::isNonZeroUnsignedInteger);
 
+            if (!isValidIndices) {
+                throw new ParseException(MESSAGE_INVALID_REDIT_ITEM_INDEX);
+            }
+
+            List<Integer> mappedIndices = Arrays.stream(indices.split("\\s+"))
+                        .map(Integer::parseInt)
+                        .collect(Collectors.toList());
             return Optional.of(mappedIndices);
         }
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,8 +33,8 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INVALID_REDIT_ITEM_INDEX = "Index provided for one of the items is not" +
-            " a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_REDIT_ITEM_INDEX = "Index provided for one of the items is not"
+            + " a non-zero unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;

--- a/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResumeEditCommandParser.java
@@ -30,12 +30,7 @@ public class ResumeEditCommandParser implements Parser<ResumeEditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_INTERNSHIP, PREFIX_SKILL, PREFIX_PROJECT);
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResumeEditCommand.MESSAGE_USAGE),
-                    pe);
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble());
 
         // Optional.empty() denotes non-existence, "" denotes that no argument specified, else some arguments specified
         Optional<List<Integer>> internshipIndices = ParserUtil.parseReditItemIndices(

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
@@ -59,5 +60,16 @@ public class ResumeEditCommandParserTest {
                         skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        // standard
+        assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "-1", ParserUtil.MESSAGE_INVALID_INDEX);
+
+        // with some item prefixes
+        assertParseFailure(parser, "a int/ 1 2 3 proj/ 3 2 1 ski/ 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "-1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERNSHIP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ResumeEditCommand;
+import seedu.address.testutil.ItemIndicesBuilder;
+
+public class ResumeEditCommandParserTest {
+    private ResumeEditCommandParser parser = new ResumeEditCommandParser();
+
+    @Test
+    public void parse_allItemsSpecified_success() {
+        ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
+        ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+        ItemIndicesBuilder skillIndicesBuilder=  new ItemIndicesBuilder().add(1);
+
+        // Standard
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL +
+                        " " + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
+                        projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // Shuffle the order of prefixes
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
+                        " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // multiple project prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // multiple internship prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // multiple skill prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_ITEM;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ResumeEditCommand;
-import seedu.address.model.item.Item;
 import seedu.address.testutil.ItemIndicesBuilder;
 
 public class ResumeEditCommandParserTest {
@@ -191,29 +190,42 @@ public class ResumeEditCommandParserTest {
         assertParseFailure(parser, "-1", ParserUtil.MESSAGE_INVALID_INDEX);
 
         // with some item prefixes
-        assertParseFailure(parser, "a int/ 1 2 3 proj/ 3 2 1 ski/ 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
-        assertParseFailure(parser, "-1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
-        assertParseFailure(parser, "1 1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "a " + PREFIX_INTERNSHIP + " 1 2 3 " + PREFIX_PROJECT + " 3 2 1 " +
+                        PREFIX_SKILL + " 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "-1 " + PREFIX_PROJECT + " 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "1 1 " + PREFIX_PROJECT + " 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 
     @Test
     public void parse_invalidReditItemIndices_throwsParseException() {
         // standard
-        assertParseFailure(parser, "1 int/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "1 int/ -1", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "2 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "2 proj/ -1", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "3 ski/ 0", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "3 ski/ 100@", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "1 " + PREFIX_INTERNSHIP + " a",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "1 " + PREFIX_INTERNSHIP + " -1",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_PROJECT + " a",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_PROJECT + " -1",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 " + PREFIX_SKILL + " 0",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 " + PREFIX_SKILL + " 100@",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
 
         // mix valid and invalid
-        assertParseFailure(parser, "2 proj/ -1 ski/ 1 2 3", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "2 int/ 3 1 2 ski/ @", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "2 int/ 3 2 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_PROJECT + " -1 " + PREFIX_SKILL + " 1 2 3",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_INTERNSHIP + " 3 1 2 " + PREFIX_SKILL + " @",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_INTERNSHIP + " 3 2 " + PREFIX_PROJECT + " a",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
 
         // all invalid
-        assertParseFailure(parser, "2 int/ -1 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "3 int/ -1 proj/ a ski/ 0", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 " + PREFIX_INTERNSHIP + " -1 " + PREFIX_PROJECT + " a",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 " + PREFIX_INTERNSHIP + " -1 " + PREFIX_PROJECT + " a " +
+                PREFIX_SKILL + " 0",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -20,8 +20,8 @@ public class ResumeEditCommandParserTest {
     @Test
     public void parse_allItemsSpecified_success() {
         ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
-        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder().add(1);
         ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder().add(1);
 
         // Standard
         assertParseSuccess(parser,
@@ -187,6 +187,61 @@ public class ResumeEditCommandParserTest {
     }
 
     @Test
+    public void parse_itemsSpecifiedButNoIndex_success() {
+        ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder();
+        ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder();
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder();
+
+        // clear all
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + PREFIX_PROJECT + " " + PREFIX_SKILL,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // clear only two
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + PREFIX_SKILL,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " " + PREFIX_SKILL,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // clear only one
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        ItemIndicesBuilder.empty()));
+
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+    }
+
+    @Test
+    public void parse_mixAndMatchItemSpecifiedButNoIndex_success() {
+        ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(4).add(3);
+        ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(2).add(4).add(1);
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder();
+
+        // fill up the internship and project, but empty the skill
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " "
+                        + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_SKILL,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        skillIndicesBuilder.build()));
+
+        // fill up the internship, but empty the skill
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL,
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+    }
+
+    @Test
     public void parse_invalidResumeIndex_throwsParseException() {
         // standard
         assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
@@ -232,7 +287,7 @@ public class ResumeEditCommandParserTest {
     }
 
     @Test
-    public void parseVariousTypo_throwsParseException() {
+    public void parse_variousTypo_throwsParseException() {
         // Forgot to specify index and go to item prefixes directly -- Parser expects an index
         assertParseFailure(parser, PREFIX_INTERNSHIP + "1 2", ParserUtil.MESSAGE_INVALID_INDEX);
 

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ResumeEditCommand;
+import seedu.address.model.item.Item;
 import seedu.address.testutil.ItemIndicesBuilder;
 
 public class ResumeEditCommandParserTest {
@@ -18,8 +19,8 @@ public class ResumeEditCommandParserTest {
     @Test
     public void parse_allItemsSpecified_success() {
         ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
+        ItemIndicesBuilder skillIndicesBuilder =  new ItemIndicesBuilder().add(1);
         ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
-        ItemIndicesBuilder skillIndicesBuilder=  new ItemIndicesBuilder().add(1);
 
         // Standard
         assertParseSuccess(parser,
@@ -63,6 +64,78 @@ public class ResumeEditCommandParserTest {
     }
 
     @Test
+    public void parse_intAndProjSpecified_success() {
+        ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
+        ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+
+        // Standard
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " +
+                        PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+
+        // Shuffle the order of prefixes
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
+                        " " + internshipIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+
+        // multiple internship prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
+                        projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+
+        // multiple project prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
+                        projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+    }
+
+    @Test
+    public void parse_intAndSkiSpecified_success() {
+        ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+
+        // Standard
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " +
+                        PREFIX_SKILL + " " + skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+
+        // Shuffle the order of prefixes
+        assertParseSuccess(parser,
+                "1 " + PREFIX_SKILL + " " + skillIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
+                        " " + internshipIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+
+        // multiple internship prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+
+        // multiple project prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " " +
+                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
+                        skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+    }
+
+    @Test
     public void parse_invalidIndex_throwsParseException() {
         // standard
         assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
@@ -71,5 +144,6 @@ public class ResumeEditCommandParserTest {
         // with some item prefixes
         assertParseFailure(parser, "a int/ 1 2 3 proj/ 3 2 1 ski/ 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "-1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "1 1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_ITEM;
 
 import org.junit.jupiter.api.Test;
 
@@ -126,13 +127,60 @@ public class ResumeEditCommandParserTest {
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
 
-        // multiple project prefixes -- only last one accepted
+        // multiple skill prefixes -- only last one accepted
         assertParseSuccess(parser,
                 "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " " +
                         internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
                         skillIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
+    }
+
+    @Test
+    public void parse_onlyProjSpecified_success() {
+        ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+
+        // Standard
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty() ,projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+
+        // multiple project prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), projectIndicesBuilder.build(),
+                        ItemIndicesBuilder.empty()));
+    }
+
+    @Test
+    public void parse_onlySkiSpecified_success() {
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
+
+        // Standard
+        assertParseSuccess(parser,
+                "1 " + PREFIX_SKILL + " " + skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+
+        // multiple skill prefixes -- only last one accepted
+        assertParseSuccess(parser,
+                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_SKILL + " " + skillIndicesBuilder.toString(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), ItemIndicesBuilder.empty(),
+                        skillIndicesBuilder.build()));
+    }
+
+    @Test
+    public void parse_nothingSpecified_success() {
+        assertParseSuccess(parser,
+                "1",
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), ItemIndicesBuilder.empty(),
+                        ItemIndicesBuilder.empty()));
+
+        assertParseSuccess(parser,
+                "4",
+                new ResumeEditCommand(INDEX_FOURTH_ITEM, ItemIndicesBuilder.empty(), ItemIndicesBuilder.empty(),
+                        ItemIndicesBuilder.empty()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -184,7 +184,7 @@ public class ResumeEditCommandParserTest {
     }
 
     @Test
-    public void parse_invalidIndex_throwsParseException() {
+    public void parse_invalidResumeIndex_throwsParseException() {
         // standard
         assertParseFailure(parser, "a", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "-1", ParserUtil.MESSAGE_INVALID_INDEX);
@@ -193,5 +193,25 @@ public class ResumeEditCommandParserTest {
         assertParseFailure(parser, "a int/ 1 2 3 proj/ 3 2 1 ski/ 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "-1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "1 1 proj/ 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_invalidReditItemIndices_throwsParseException() {
+        // standard
+        assertParseFailure(parser, "1 int/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "1 int/ -1", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 proj/ -1", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 ski/ 0", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 ski/ 100@", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+
+        // mix valid and invalid
+        assertParseFailure(parser, "2 proj/ -1 ski/ 1 2 3", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 int/ 3 1 2 ski/ @", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "2 int/ 3 2 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+
+        // all invalid
+        assertParseFailure(parser, "2 int/ -1 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+        assertParseFailure(parser, "3 int/ -1 proj/ a ski/ 0", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -20,46 +20,49 @@ public class ResumeEditCommandParserTest {
     @Test
     public void parse_allItemsSpecified_success() {
         ItemIndicesBuilder internshipIndicesBuilder = new ItemIndicesBuilder().add(1).add(3).add(4);
-        ItemIndicesBuilder skillIndicesBuilder =  new ItemIndicesBuilder().add(1);
+        ItemIndicesBuilder skillIndicesBuilder = new ItemIndicesBuilder().add(1);
         ItemIndicesBuilder projectIndicesBuilder = new ItemIndicesBuilder().add(1).add(2);
 
         // Standard
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL +
-                        " " + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
-                        projectIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL
+                        + " " + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
 
         // Shuffle the order of prefixes
         assertParseSuccess(parser,
-                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
-                        " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString(),
+                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP
+                        + " " + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
 
         // multiple project prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
 
         // multiple internship prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
 
         // multiple skill prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         skillIndicesBuilder.build()));
     }
@@ -71,31 +74,31 @@ public class ResumeEditCommandParserTest {
 
         // Standard
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " +
-                        PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " "
+                        + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         ItemIndicesBuilder.empty()));
 
         // Shuffle the order of prefixes
         assertParseSuccess(parser,
-                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
-                        " " + internshipIndicesBuilder.toString(),
+                "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP
+                        + " " + internshipIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         ItemIndicesBuilder.empty()));
 
         // multiple internship prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
-                        projectIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         ItemIndicesBuilder.empty()));
 
         // multiple project prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " " +
-                        projectIndicesBuilder.toString(),
+                "1 " + PREFIX_PROJECT + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_PROJECT + " "
+                        + projectIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), projectIndicesBuilder.build(),
                         ItemIndicesBuilder.empty()));
     }
@@ -107,31 +110,31 @@ public class ResumeEditCommandParserTest {
 
         // Standard
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " " +
-                        PREFIX_SKILL + " " + skillIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " " + internshipIndicesBuilder.toString() + " "
+                        + PREFIX_SKILL + " " + skillIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
 
         // Shuffle the order of prefixes
         assertParseSuccess(parser,
-                "1 " + PREFIX_SKILL + " " + skillIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP +
-                        " " + internshipIndicesBuilder.toString(),
+                "1 " + PREFIX_SKILL + " " + skillIndicesBuilder.toString() + " " + PREFIX_INTERNSHIP
+                        + " " + internshipIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
 
         // multiple internship prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString(),
+                "1 " + PREFIX_INTERNSHIP + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
 
         // multiple skill prefixes -- only last one accepted
         assertParseSuccess(parser,
-                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " " +
-                        internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " " +
-                        skillIndicesBuilder.toString(),
+                "1 " + PREFIX_SKILL + " 100 200 " + PREFIX_INTERNSHIP + " "
+                        + internshipIndicesBuilder.toString() + " " + PREFIX_SKILL + " "
+                        + skillIndicesBuilder.toString(),
                 new ResumeEditCommand(INDEX_FIRST_ITEM, internshipIndicesBuilder.build(), ItemIndicesBuilder.empty(),
                         skillIndicesBuilder.build()));
     }
@@ -143,7 +146,7 @@ public class ResumeEditCommandParserTest {
         // Standard
         assertParseSuccess(parser,
                 "1 " + PREFIX_PROJECT + " " + projectIndicesBuilder.toString(),
-                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty() ,projectIndicesBuilder.build(),
+                new ResumeEditCommand(INDEX_FIRST_ITEM, ItemIndicesBuilder.empty(), projectIndicesBuilder.build(),
                         ItemIndicesBuilder.empty()));
 
         // multiple project prefixes -- only last one accepted
@@ -190,8 +193,8 @@ public class ResumeEditCommandParserTest {
         assertParseFailure(parser, "-1", ParserUtil.MESSAGE_INVALID_INDEX);
 
         // with some item prefixes
-        assertParseFailure(parser, "a " + PREFIX_INTERNSHIP + " 1 2 3 " + PREFIX_PROJECT + " 3 2 1 " +
-                        PREFIX_SKILL + " 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "a " + PREFIX_INTERNSHIP + " 1 2 3 " + PREFIX_PROJECT + " 3 2 1 "
+                        + PREFIX_SKILL + " 2 1", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "-1 " + PREFIX_PROJECT + " 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "1 1 " + PREFIX_PROJECT + " 4 1 2", ParserUtil.MESSAGE_INVALID_INDEX);
     }
@@ -223,8 +226,8 @@ public class ResumeEditCommandParserTest {
         // all invalid
         assertParseFailure(parser, "2 " + PREFIX_INTERNSHIP + " -1 " + PREFIX_PROJECT + " a",
                 ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
-        assertParseFailure(parser, "3 " + PREFIX_INTERNSHIP + " -1 " + PREFIX_PROJECT + " a " +
-                PREFIX_SKILL + " 0",
+        assertParseFailure(parser, "3 " + PREFIX_INTERNSHIP + " -1 " + PREFIX_PROJECT + " a "
+                + PREFIX_SKILL + " 0",
                 ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResumeEditCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.model.util.ItemUtil.PROJECT_ALIAS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_ITEM;
 
@@ -213,5 +214,19 @@ public class ResumeEditCommandParserTest {
         // all invalid
         assertParseFailure(parser, "2 int/ -1 proj/ a", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
         assertParseFailure(parser, "3 int/ -1 proj/ a ski/ 0", ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
+    }
+
+    @Test
+    public void parseVariousTypo_throwsParseException() {
+        // Forgot to specify index and go to item prefixes directly -- Parser expects an index
+        assertParseFailure(parser, PREFIX_INTERNSHIP + "1 2", ParserUtil.MESSAGE_INVALID_INDEX);
+
+        // Space between slash and prefix, right after index -- Parser thinks that the mistyped prefix is part of index
+        assertParseFailure(parser, "1 " + PROJECT_ALIAS + " /", ParserUtil.MESSAGE_INVALID_INDEX);
+
+        // Space between slash and prefix, right after a correct prefix -- Parser thinks it's part of the indices of
+        // the correctly-written prefix
+        assertParseFailure(parser, "1 " + PREFIX_INTERNSHIP + " 1 2 " + PROJECT_ALIAS + " / 2 3",
+                ParserUtil.MESSAGE_INVALID_REDIT_ITEM_INDEX);
     }
 }

--- a/src/test/java/seedu/address/testutil/ItemIndicesBuilder.java
+++ b/src/test/java/seedu/address/testutil/ItemIndicesBuilder.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A builder class to support testing of ResumeEditCommand and TagPullCommand.
@@ -42,5 +43,14 @@ public class ItemIndicesBuilder {
 
     public Optional<List<Integer>> build() {
         return Optional.of(itemIndices);
+    }
+
+    @Override
+    public String toString() {
+        return itemIndices
+                .stream()
+                .distinct()
+                .map(Object::toString)
+                .collect(Collectors.joining(" "));
     }
 }


### PR DESCRIPTION
Fixes #244 

ResumeEditCommandParser test based on:
POSITIVE TEST CASES
1. All 3 items prefixes are specified
2. Pairs of items prefixes are specified
3. Single item prefixes are specified
4. Nothing specified
5. Items prefixes are specified but with no indices (aka clearing it)

NEGATIVE TEST CASES
1. Wrong indices for resume
2. Wrong indices for the redits
3. Some possible typos