### PR TITLE
Refactor feedbackToUser for Redit and Tagpull

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResumeEditCommand.java
@@ -36,6 +36,8 @@ public class ResumeEditCommand extends Command {
             + PREFIX_SKILL + " 1 2 "
             + PREFIX_PROJECT + " 1 ";
 
+    public static final String MESSAGE_SUCCESS = "Contents of Resume has been updated!";
+
     protected final Index index;
     protected final Optional<List<Integer>> internshipIndices;
     protected final Optional<List<Integer>> projectIndices;
@@ -100,7 +102,7 @@ public class ResumeEditCommand extends Command {
         model.setResumeToDisplay();
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
         model.commitResumeBook();
-        return new ResumeEditCommandResult(editedResume.toString(), "Resume is updated",
+        return new ResumeEditCommandResult(editedResume.toString(), MESSAGE_SUCCESS,
                 model.getDisplayType());
     }
 

--- a/src/main/java/seedu/address/logic/commands/TagPullCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagPullCommand.java
@@ -36,6 +36,8 @@ public class TagPullCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + " tech";
 
+    public static final String MESSAGE_SUCCESS = "Items pulled:\n%1$d internship(s), %2$d project(s), %3$d skill(s).";
+
     protected final Index index;
     protected final Set<Tag> tagList;
 
@@ -112,12 +114,11 @@ public class TagPullCommand extends Command {
         model.updateFilteredItemList(PREDICATE_SHOW_ALL_ITEMS);
         model.commitResumeBook();
 
-        String feedbackToUser = new StringBuilder()
-                .append("Items pulled:\n")
-                .append(internshipCountAfter - internshipCountBefore).append(" internship(s), ")
-                .append(projectCountAfter - projectCountBefore).append(" project(s), ")
-                .append(skillCountAfter - skillCountBefore).append(" skill(s).")
-                .toString();
+        int internshipCountChange = internshipCountAfter - internshipCountBefore;
+        int projectCountChange = projectCountAfter - projectCountBefore;
+        int skillCountChange = skillCountAfter - skillCountBefore;
+        String feedbackToUser = String.format(MESSAGE_SUCCESS, internshipCountChange, projectCountChange,
+                skillCountChange);
 
         return new TagPullCommandResult(editedResume.toString(), feedbackToUser,
                 model.getDisplayType());

--- a/src/test/java/seedu/address/logic/commands/ResumeEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ResumeEditCommandTest.java
@@ -150,7 +150,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)
@@ -172,7 +172,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)
@@ -193,7 +193,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)
@@ -214,7 +214,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)
@@ -233,7 +233,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)
@@ -253,7 +253,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.FILLED_RESUME)
@@ -272,7 +272,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.FILLED_RESUME)
@@ -292,7 +292,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.FILLED_RESUME)
@@ -313,7 +313,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.FILLED_RESUME)
@@ -335,7 +335,7 @@ public class ResumeEditCommandTest {
                 skillIndices);
 
         CommandResult commandResult = resumeEditCommand.execute(model);
-        assertEquals("Resume is updated", commandResult.getFeedbackToUser());
+        assertEquals(ResumeEditCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
 
         Resume changedResume = model.getResumeByIndex(validIndex);
         Resume expectedResume = new ResumeBuilder(TypicalResume.ME_RESUME)

--- a/src/test/java/seedu/address/logic/commands/TagPullCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagPullCommandTest.java
@@ -36,7 +36,6 @@ import seedu.address.testutil.TypicalSkill;
 
 public class TagPullCommandTest {
     private Model model;
-    private String feedbackToUser = "Items pulled:\n%1$d internship(s), %2$d project(s), %3$d skill(s).";
 
     @BeforeEach
     public void setUp() {
@@ -81,14 +80,16 @@ public class TagPullCommandTest {
 
         // Resume at first index
         CommandResult commandResultFirstIndex = new TagPullCommand(firstIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 2, 2, 2), commandResultFirstIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 2, 2, 2),
+                commandResultFirstIndex.getFeedbackToUser());
 
         Resume firstIndexResume = model.getResumeByIndex(firstIndex);
         assertEquals(firstIndexResume, expectedFirstResume);
 
         // Resume at third index
         CommandResult commandResultThirdIndex = new TagPullCommand(thirdIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 1, 1, 1), commandResultThirdIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 1, 1, 1),
+                commandResultThirdIndex.getFeedbackToUser());
 
         Resume thirdIndexResume = model.getResumeByIndex(thirdIndex);
         assertEquals(thirdIndexResume, expectedThirdResume);
@@ -108,7 +109,7 @@ public class TagPullCommandTest {
                 .build();
 
         CommandResult commandResult = new TagPullCommand(index, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 0, 0, 1), commandResult.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 0, 0, 1), commandResult.getFeedbackToUser());
 
         Resume resume = model.getResumeByIndex(index);
         assertEquals(resume, expectedResume);
@@ -126,7 +127,7 @@ public class TagPullCommandTest {
                 .build();
 
         CommandResult commandResult = new TagPullCommand(index, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 1, 0, 1), commandResult.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 1, 0, 1), commandResult.getFeedbackToUser());
 
         Resume resume = model.getResumeByIndex(index);
         assertEquals(resume, expectedResume);
@@ -150,14 +151,16 @@ public class TagPullCommandTest {
 
         // Resume at first index
         CommandResult commandResultFirstIndex = new TagPullCommand(firstIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 0, 0, 0), commandResultFirstIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 0, 0, 0),
+                commandResultFirstIndex.getFeedbackToUser());
 
         Resume firstIndexResume = model.getResumeByIndex(firstIndex);
         assertEquals(firstIndexResume, expectedFirstResume);
 
         // Resume at third index
         CommandResult commandResultThirdIndex = new TagPullCommand(thirdIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 0, 0, 0), commandResultThirdIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 0, 0, 0),
+                commandResultThirdIndex.getFeedbackToUser());
 
         Resume thirdIndexResume = model.getResumeByIndex(thirdIndex);
         assertEquals(thirdIndexResume, expectedThirdResume);
@@ -179,13 +182,13 @@ public class TagPullCommandTest {
                 .build();
 
         CommandResult commandResult = new TagPullCommand(index, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 2, 2, 2), commandResult.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 2, 2, 2), commandResult.getFeedbackToUser());
 
         Resume resume = model.getResumeByIndex(index);
         assertEquals(resume, expectedResume);
 
         CommandResult commandResultAgain = new TagPullCommand(index, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 0, 0, 0), commandResultAgain.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 0, 0, 0), commandResultAgain.getFeedbackToUser());
 
         Resume resumeAgain = model.getResumeByIndex(index);
         assertEquals(resumeAgain, expectedResume);
@@ -215,14 +218,16 @@ public class TagPullCommandTest {
 
         // Resume at first index
         CommandResult commandResultFirstIndex = new TagPullCommand(firstIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 1, 1, 1), commandResultFirstIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 1, 1, 1),
+                commandResultFirstIndex.getFeedbackToUser());
 
         Resume firstIndexResume = model.getResumeByIndex(firstIndex);
         assertEquals(firstIndexResume, expectedFirstResume);
 
         // Resume at third index
         CommandResult commandResultThirdIndex = new TagPullCommand(thirdIndex, tags).execute(model);
-        assertEquals(String.format(feedbackToUser, 0, 1, 1), commandResultThirdIndex.getFeedbackToUser());
+        assertEquals(String.format(TagPullCommand.MESSAGE_SUCCESS, 0, 1, 1),
+                commandResultThirdIndex.getFeedbackToUser());
 
         Resume thirdIndexResume = model.getResumeByIndex(thirdIndex);
         assertEquals(thirdIndexResume, expectedThirdResume);


### PR DESCRIPTION
Make use of a constant `MESSAGE_SUCCESS` for both classes. 

Checked locally and it passes:
- checkstyleMain
- main.test

it fails checkstyleTest currently due to TypicalEditUserDescriptor but gonna trust that Hai fixed it elsewhere =))